### PR TITLE
Metadata default template fix

### DIFF
--- a/OFS-lib/Funscript/Funscript.cpp
+++ b/OFS-lib/Funscript/Funscript.cpp
@@ -868,14 +868,14 @@ void Funscript::Serialize(nlohmann::json& json, const FunscriptData& funscriptDa
 	auto& jsonMetadata = json["metadata"];
 	OFS::Serializer<false>::Serialize(metadata, jsonMetadata);
 	// Ensure duration is saved with millisecond precision (0.000)
+	// Round duration for compatibility with XTPlayer.
 	if (jsonMetadata.contains("duration") && jsonMetadata["duration"].is_number()) {
-		double rounded = std::round(metadata.duration * 1000.0) / 1000.0;
-		jsonMetadata["duration"] = rounded;
+		jsonMetadata["duration"] = (int64_t)std::round(metadata.duration);
 	}
 	// Add a human-readable duration string for compatibility consumers
 	{
 		char durationBuf[32] = {};
-		Util::FormatTime(durationBuf, sizeof(durationBuf), (float)metadata.duration, true);
+		Util::FormatTime(durationBuf, sizeof(durationBuf), (float)metadata.duration, false);
 		jsonMetadata["durationTime"] = std::string(durationBuf);
 	}
 	if(includeChapters)

--- a/src/OpenFunscripter.cpp
+++ b/src/OpenFunscripter.cpp
@@ -10,6 +10,7 @@
 #include "OFS_Localization.h"
 
 #include "state/OpenFunscripterState.h"
+#include "state/MetadataEditorState.h"
 #include "state/states/VideoplayerWindowState.h"
 #include "state/states/BaseOverlayState.h"
 #include "state/states/ChapterState.h"
@@ -1823,6 +1824,12 @@ void OpenFunscripter::initProject() noexcept
     if (LoadedProject->IsValid()) {
         auto& projectState = LoadedProject->State();
         if (projectState.nudgeMetadata) {
+            // Apply saved default metadata template to new projects
+            auto& metaState = FunscriptMetadataState::State(metadataEditor->StateHandle());
+            auto savedDuration = projectState.metadata.duration;
+            projectState.metadata = metaState.defaultMetadata;
+            projectState.metadata.duration = savedDuration;
+
             const auto& prefState = PreferenceState::State(preferences->StateHandle());
             ShowMetadataEditor = prefState.showMetaOnNew;
             projectState.nudgeMetadata = false;

--- a/src/lua/OFS_LuaCoreExtension.cpp
+++ b/src/lua/OFS_LuaCoreExtension.cpp
@@ -121,6 +121,7 @@ function binding.spline_smooth()
             time_ms = action2.at + (i*pointEverySecond)
             spline_pos = catmullRom(action1.pos, action2.pos, action3.pos, action4.pos, s)
             spline_pos = clamp(spline_pos, 0, 100)
+            spline_pos = math.floor(spline_pos + 0.5)
             table.insert( smoothedActions, {at=time_ms, pos=spline_pos} )
         end
         ::continue::


### PR DESCRIPTION
Metadata default template successfully saves but initProject() never loaded it. This auto loads the template when creating a new project.