### PR TITLE
Add a 3D multi-axis simulator and an animated preview exporter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required(VERSION 3.16)
 
+# Bundled dependencies (glm, SDL2, json, bitsery, civetweb, eventpp) still declare
+# cmake_minimum_required() < 3.5, which CMake 4.0+ rejects. This lets them configure
+# without editing each submodule. Cascades into all add_subdirectory() children.
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+
 project(scripter)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin")

--- a/OFS-lib/Funscript/Funscript.cpp
+++ b/OFS-lib/Funscript/Funscript.cpp
@@ -867,15 +867,14 @@ void Funscript::Serialize(nlohmann::json& json, const FunscriptData& funscriptDa
 
 	auto& jsonMetadata = json["metadata"];
 	OFS::Serializer<false>::Serialize(metadata, jsonMetadata);
-	// Ensure duration is saved with millisecond precision (0.000)
+	// Round duration to whole seconds for compatibility with XTPlayer.
 	if (jsonMetadata.contains("duration") && jsonMetadata["duration"].is_number()) {
-		double rounded = std::round(metadata.duration * 1000.0) / 1000.0;
-		jsonMetadata["duration"] = rounded;
+		jsonMetadata["duration"] = (int64_t)std::round(metadata.duration);
 	}
 	// Add a human-readable duration string for compatibility consumers
 	{
 		char durationBuf[32] = {};
-		Util::FormatTime(durationBuf, sizeof(durationBuf), (float)metadata.duration, true);
+		Util::FormatTime(durationBuf, sizeof(durationBuf), (float)metadata.duration, false);
 		jsonMetadata["durationTime"] = std::string(durationBuf);
 	}
 	if(includeChapters)

--- a/OFS-lib/Funscript/FunscriptHeatmap.cpp
+++ b/OFS-lib/Funscript/FunscriptHeatmap.cpp
@@ -137,63 +137,63 @@ void HeatmapShader::SpeedTex(uint32_t unit) noexcept
     glUniform1i(SpeedLoc, unit);
 }
 
+std::vector<std::pair<float, ImU32>> FunscriptHeatmap::LinePreset(int32_t profile) noexcept
+{
+    if (profile == LineProfile::Classic) {
+        // The original OpenFunscripter line palette: white -> green -> yellow -> red.
+        const ImU32 classic[] = {
+            IM_COL32(0xFF, 0xFF, 0xFF, 0xFF),
+            IM_COL32(0x66, 0xFF, 0x00, 0xFF),
+            IM_COL32(0xFF, 0xFF, 0x00, 0xFF),
+            IM_COL32(0xFF, 0x00, 0x00, 0xFF),
+        };
+        // Upstream OFS normalized speed to 400, not this fork's 2000. Compress the
+        // stops into that fraction of the speed axis so the mapping matches the
+        // original (fully red at >= 400/s) instead of looking washed out.
+        constexpr float kClassicMaxSpeed = 400.f;
+        const float scale = kClassicMaxSpeed / MaxSpeedPerSecond;
+        std::vector<std::pair<float, ImU32>> stops;
+        const int n = (int)(sizeof(classic) / sizeof(classic[0]));
+        for (int i = 0; i < n; ++i) stops.emplace_back(((float)i / (n - 1)) * scale, classic[i]);
+        return stops;
+    }
+
+    // Fork: detailed speed colors 0-2000 (step 50).
+    static const ImU32 fork[] = {
+        IM_COL32(0x00, 0xEE, 0xFF, 0xFF), IM_COL32(0x00, 0xFF, 0xF3, 0xFF), IM_COL32(0x00, 0xFF, 0x8A, 0xFF),
+        IM_COL32(0x00, 0xF7, 0x00, 0xFF), IM_COL32(0x78, 0xE0, 0x00, 0xFF), IM_COL32(0xE8, 0xBD, 0x00, 0xFF),
+        IM_COL32(0xFF, 0x8C, 0x00, 0xFF), IM_COL32(0xFF, 0x40, 0x00, 0xFF), IM_COL32(0xFF, 0x00, 0x00, 0xFF),
+        IM_COL32(0xFF, 0x00, 0x1E, 0xFF), IM_COL32(0xFF, 0x00, 0xAB, 0xFF), IM_COL32(0xFF, 0x00, 0xC4, 0xFF),
+        IM_COL32(0x96, 0x00, 0xC5, 0xFF), IM_COL32(0x77, 0x00, 0xF9, 0xFF), IM_COL32(0x52, 0x00, 0xFF, 0xFF),
+        IM_COL32(0x00, 0x00, 0xFF, 0xFF), IM_COL32(0x00, 0x03, 0xFE, 0xFF), IM_COL32(0x00, 0x5A, 0x9B, 0xFF),
+        IM_COL32(0x00, 0x57, 0x58, 0xFF), IM_COL32(0x00, 0x58, 0x44, 0xFF), IM_COL32(0x04, 0x57, 0x2D, 0xFF),
+        IM_COL32(0x32, 0x52, 0x10, 0xFF), IM_COL32(0x4A, 0x4C, 0x00, 0xFF), IM_COL32(0x5C, 0x44, 0x00, 0xFF),
+        IM_COL32(0x69, 0x3C, 0x00, 0xFF), IM_COL32(0x71, 0x34, 0x0A, 0xFF), IM_COL32(0x74, 0x2E, 0x27, 0xFF),
+        IM_COL32(0x73, 0x2D, 0x3E, 0xFF), IM_COL32(0x6D, 0x2E, 0x52, 0xFF), IM_COL32(0x62, 0x32, 0x64, 0xFF),
+        IM_COL32(0x54, 0x37, 0x72, 0xFF), IM_COL32(0x42, 0x3E, 0x7B, 0xFF), IM_COL32(0x2A, 0x45, 0x7D, 0xFF),
+        IM_COL32(0x00, 0x4C, 0x78, 0xFF), IM_COL32(0x00, 0x52, 0x6E, 0xFF), IM_COL32(0x00, 0x56, 0x5D, 0xFF),
+        IM_COL32(0x00, 0x58, 0x4A, 0xFF), IM_COL32(0x00, 0x57, 0x33, 0xFF), IM_COL32(0x29, 0x54, 0x19, 0xFF),
+        IM_COL32(0x44, 0x4E, 0x00, 0xFF), IM_COL32(0x57, 0x46, 0x00, 0xFF),
+    };
+    std::vector<std::pair<float, ImU32>> stops;
+    const int n = (int)(sizeof(fork) / sizeof(fork[0]));
+    for (int i = 0; i < n; ++i) stops.emplace_back((float)i / (n - 1), fork[i]);
+    return stops;
+}
+
+void FunscriptHeatmap::SetLineColors(const std::vector<std::pair<float, ImU32>>& stops) noexcept
+{
+    LineColors.clear();
+    for (auto& s : stops) LineColors.addMark(Util::Clamp(s.first, 0.f, 1.f), ImColor(s.second));
+    if (LineColors.getMarks().empty()) LineColors.addMark(0.f, ImColor(IM_COL32_WHITE));
+    LineColors.refreshCache();
+}
+
 void FunscriptHeatmap::Init() noexcept
 {
     if(LineColors.getMarks().empty())
     {
-        // Speed colors 0-2000 (step 50), blended with white for low speeds
-        // speed, name, #hex (og #hex @ alpha)
-        std::array<ImColor, 41> heatColor {
-        //  IM_COL32(0xFF, 0xFF, 0xFF, 0xFF),  // 0    white   #ffffff (og #00eeff @ 0.0)
-        //  IM_COL32(0x80, 0xFF, 0xF9, 0xFF),  // 50   cyan    #80fff9 (og #00fff3 @ 0.5)
-            IM_COL32(0x00, 0xEE, 0xFF, 0xFF),  // 0    cyan    #00eeff
-            IM_COL32(0x00, 0xFF, 0xF3, 0xFF),  // 50   cyan    #00fff3
-            IM_COL32(0x00, 0xFF, 0x8A, 0xFF),  // 100  lime    #00ff8a
-            IM_COL32(0x00, 0xF7, 0x00, 0xFF),  // 150  lime    #00f700
-            IM_COL32(0x78, 0xE0, 0x00, 0xFF),  // 200  lime    #78e000
-            IM_COL32(0xE8, 0xBD, 0x00, 0xFF),  // 250  gold    #e8bd00
-            IM_COL32(0xFF, 0x8C, 0x00, 0xFF),  // 300  orange  #ff8c00
-            IM_COL32(0xFF, 0x40, 0x00, 0xFF),  // 350  orange  #ff4000
-            IM_COL32(0xFF, 0x00, 0x00, 0xFF),  // 400  red     #ff0000
-            IM_COL32(0xFF, 0x00, 0x1E, 0xFF),  // 450  red     #ff001e
-            IM_COL32(0xFF, 0x00, 0xAB, 0xFF),  // 500  magenta #ff00ab
-            IM_COL32(0xFF, 0x00, 0xC4, 0xFF),  // 550  magenta #ff00c4
-            IM_COL32(0x96, 0x00, 0xC5, 0xFF),  // 600  violet  #9600c5
-            IM_COL32(0x77, 0x00, 0xF9, 0xFF),  // 650  purple  #7700f9
-            IM_COL32(0x52, 0x00, 0xFF, 0xFF),  // 700  blue    #5200ff
-            IM_COL32(0x00, 0x00, 0xFF, 0xFF),  // 750  blue    #0000ff
-            IM_COL32(0x00, 0x03, 0xFE, 0xFF),  // 800  blue    #0003fe
-            IM_COL32(0x00, 0x5A, 0x9B, 0xFF),  // 850  blue    #005a9b
-            IM_COL32(0x00, 0x57, 0x58, 0xFF),  // 900  teal    #005758
-            IM_COL32(0x00, 0x58, 0x44, 0xFF),  // 950  teal    #005844
-            IM_COL32(0x04, 0x57, 0x2D, 0xFF),  // 1000 green   #04572d
-            IM_COL32(0x32, 0x52, 0x10, 0xFF),  // 1050 green   #325210
-            IM_COL32(0x4A, 0x4C, 0x00, 0xFF),  // 1100 olive   #4a4c00
-            IM_COL32(0x5C, 0x44, 0x00, 0xFF),  // 1150 olive   #5c4400
-            IM_COL32(0x69, 0x3C, 0x00, 0xFF),  // 1200 brown   #693c00
-            IM_COL32(0x71, 0x34, 0x0A, 0xFF),  // 1250 brown   #71340a
-            IM_COL32(0x74, 0x2E, 0x27, 0xFF),  // 1300 maroon  #742e27
-            IM_COL32(0x73, 0x2D, 0x3E, 0xFF),  // 1350 maroon  #732d3e
-            IM_COL32(0x6D, 0x2E, 0x52, 0xFF),  // 1400 purple  #6d2e52
-            IM_COL32(0x62, 0x32, 0x64, 0xFF),  // 1450 purple  #623264
-            IM_COL32(0x54, 0x37, 0x72, 0xFF),  // 1500 indigo  #543772
-            IM_COL32(0x42, 0x3E, 0x7B, 0xFF),  // 1550 indigo  #423e7b
-            IM_COL32(0x2A, 0x45, 0x7D, 0xFF),  // 1600 navy    #2a457d
-            IM_COL32(0x00, 0x4C, 0x78, 0xFF),  // 1650 navy    #004c78
-            IM_COL32(0x00, 0x52, 0x6E, 0xFF),  // 1700 teal    #00526e
-            IM_COL32(0x00, 0x56, 0x5D, 0xFF),  // 1750 teal    #00565d
-            IM_COL32(0x00, 0x58, 0x4A, 0xFF),  // 1800 green   #00584a
-            IM_COL32(0x00, 0x57, 0x33, 0xFF),  // 1850 green   #005733
-            IM_COL32(0x29, 0x54, 0x19, 0xFF),  // 1900 green   #295419
-            IM_COL32(0x44, 0x4E, 0x00, 0xFF),  // 1950 olive   #444e00
-            IM_COL32(0x57, 0x46, 0x00, 0xFF),  // 2000 olive   #574600
-        };
-        float pos = 0.0f;
-        for (auto& col : heatColor) {
-            LineColors.addMark(pos, col);
-            pos += (1.f / (heatColor.size() - 1));
-        }
-        LineColors.refreshCache();
+        SetLineColors(LinePreset(LineProfile::Fork));
     }
     Shader = std::make_unique<HeatmapShader>();
 }

--- a/OFS-lib/Funscript/FunscriptHeatmap.h
+++ b/OFS-lib/Funscript/FunscriptHeatmap.h
@@ -2,6 +2,11 @@
 #include "GradientBar.h"
 #include "Funscript.h"
 
+#include "imgui.h"
+
+#include <utility>
+#include <vector>
+
 class FunscriptHeatmap
 {
 public:
@@ -11,6 +16,12 @@ public:
 	static ImGradient LineColors;
 
 	static void Init() noexcept;
+
+	// Built-in action-line palettes. 0 = Fork (detailed 41-stop), 1 = Classic (OFS).
+	enum LineProfile : int32_t { Fork = 0, Classic = 1, Custom = 2 };
+	static std::vector<std::pair<float, ImU32>> LinePreset(int32_t profile) noexcept;
+	// Rebuild LineColors from an ordered list of (pos 0..1, RGBA) stops.
+	static void SetLineColors(const std::vector<std::pair<float, ImU32>>& stops) noexcept;
 
 	uint32_t speedTexture = 0;
 

--- a/OFS-lib/OFS_DynamicFontAtlas.cpp
+++ b/OFS-lib/OFS_DynamicFontAtlas.cpp
@@ -15,6 +15,7 @@ OFS_DynFontAtlas* OFS_DynFontAtlas::ptr = nullptr;
 
 ImFont* OFS_DynFontAtlas::DefaultFont = nullptr;
 ImFont* OFS_DynFontAtlas::DefaultFont2 = nullptr;
+ImFont* OFS_DynFontAtlas::NumberFont = nullptr;
 
 std::string OFS_DynFontAtlas::FontOverride;
 
@@ -95,6 +96,9 @@ void OFS_DynFontAtlas::RebuildFont(float fontSize) noexcept
         auto& io = ImGui::GetIO();
         GLuint fontTexture = (GLuint)(intptr_t)io.Fonts->TexID;
         io.Fonts->Clear();
+        // Clear() frees the old ImFonts; null this now so the fallback path below
+        // can't leave a dangling pointer behind.
+        ptr->NumberFont = nullptr;
 
         auto roboto = Util::Resource("fonts/RobotoMono-Regular.ttf");
         auto mainFont = FontOverride.empty() ? roboto : FontOverride;
@@ -137,6 +141,19 @@ void OFS_DynFontAtlas::RebuildFont(float fontSize) noexcept
             OFS_PROFILE("Load main font (2x)");
             font = AddFontFromFile(ptr, mainFont.c_str(), fontSize * 2.f, false);
             ptr->DefaultFont2 = font;
+        }
+        {
+            // Large digits-only face for numeric readouts. Always RobotoMono (not the
+            // user's font override) so it stays monospace: the readout keeps a stable
+            // width as the number changes. Only 0-9, so the atlas cost stays small.
+            OFS_PROFILE("Load large number font");
+            static const ImWchar digitRange[] = { '0', '9', 0 };
+            ptr->config.MergeMode = false;
+            font = io.Fonts->AddFontFromFileTTF(roboto.c_str(), NumberFontSize, &ptr->config, digitRange);
+            if (!font) {
+                LOGF_ERROR("Failed to load number font \"%s\"", roboto.c_str());
+            }
+            ptr->NumberFont = font;
         }
 
 default_font_end:

--- a/OFS-lib/OFS_DynamicFontAtlas.h
+++ b/OFS-lib/OFS_DynamicFontAtlas.h
@@ -15,6 +15,11 @@ struct OFS_DynFontAtlas {
 
     static ImFont* DefaultFont;
     static ImFont* DefaultFont2;
+    // Large digits-only face for numeric readouts. Rendering scales DOWN from this,
+    // which stays sharp, unlike scaling the UI font up. Restricting it to 0-9 keeps
+    // the atlas cost negligible despite the size. May be null if loading failed.
+    static ImFont* NumberFont;
+    static constexpr float NumberFontSize = 96.f;
 
     OFS_DynFontAtlas() noexcept;
 

--- a/OFS-lib/UI/OFS_VideoplayerControls.cpp
+++ b/OFS-lib/UI/OFS_VideoplayerControls.cpp
@@ -316,6 +316,11 @@ bool OFS_VideoplayerControls::DrawChapter(ImDrawList* drawList, const ImRect& fr
             EV::Enqueue<ExportClipForChapter>(chapter);
         }
 
+        if(ImGui::MenuItem("Export preview"))
+        {
+            EV::Enqueue<ExportPreviewForChapter>(chapter);
+        }
+
         ImGui::ColorEdit3(TR(COLOR), &chapter.color.Value.x, ImGuiColorEditFlags_NoInputs);
 
         if(ImGui::MenuItem(TR(REMOVE)))

--- a/OFS-lib/state/states/ChapterState.h
+++ b/OFS-lib/state/states/ChapterState.h
@@ -81,3 +81,11 @@ class ExportClipForChapter : public OFS_Event<ExportClipForChapter>
     ExportClipForChapter(const Chapter& chapter) noexcept
         : chapter(chapter) {}
 };
+
+class ExportPreviewForChapter : public OFS_Event<ExportPreviewForChapter>
+{
+    public:
+    Chapter chapter;
+    ExportPreviewForChapter(const Chapter& chapter) noexcept
+        : chapter(chapter) {}
+};

--- a/OFS-lib/videoplayer/OFS_Videoplayer.h
+++ b/OFS-lib/videoplayer/OFS_Videoplayer.h
@@ -56,6 +56,7 @@ class OFS_Videoplayer
 
     uint16_t VideoWidth() const noexcept;
     uint16_t VideoHeight() const noexcept;
+    bool HasAudio() const noexcept; // true when the current media has an audio track
     float FrameTime() const noexcept;
     float CurrentSpeed() const noexcept;
     float Volume() const noexcept;

--- a/OFS-lib/videoplayer/impl/OFS_MpvVideoplayer.cpp
+++ b/OFS-lib/videoplayer/impl/OFS_MpvVideoplayer.cpp
@@ -11,6 +11,7 @@
 #include "OFS_GL.h"
 
 #include <sstream>
+#include <cstring>
 
 #include "SDL_timer.h"
 #include "SDL_atomic.h"
@@ -26,6 +27,7 @@ enum MpvPropertyGet : uint64_t {
     MpvFilePath,
     MpvHwDecoder,
     MpvFramesPerSecond,
+    MpvAudioId,
 };
 
 struct MpvDataCache {
@@ -42,6 +44,7 @@ struct MpvDataCache {
     int64_t paused = false;
     int64_t videoWidth = 0;
     int64_t videoHeight = 0;
+    bool hasAudio = false;
 
     float currentVolume = .5f;
 
@@ -245,6 +248,7 @@ bool OFS_Videoplayer::Init(bool hwAccel) noexcept
 	mpv_observe_property(CTX->mpv, MpvFilePath, "path", MPV_FORMAT_STRING);
 	mpv_observe_property(CTX->mpv, MpvHwDecoder, "hwdec-current", MPV_FORMAT_STRING);
 	mpv_observe_property(CTX->mpv, MpvFramesPerSecond, "estimated-vf-fps", MPV_FORMAT_DOUBLE);
+	mpv_observe_property(CTX->mpv, MpvAudioId, "aid", MPV_FORMAT_STRING);
 
     return true;
 }
@@ -309,6 +313,14 @@ inline static void ProcessEvents(MpvPlayerContext* ctx) noexcept
                         ctx->data.fps = *(double*)prop->data;
                         ctx->data.averageFrameTime = (1.0 / ctx->data.fps);
                         break;
+                    case MpvAudioId:
+                    {
+                        // "aid" is always a defined string: a track id when the file has
+                        // audio, or "no" when it doesn't (or "auto" before it resolves).
+                        const char* aid = *(char**)prop->data;
+                        ctx->data.hasAudio = aid && std::strcmp(aid, "no") != 0;
+                        break;
+                    }
                     case MpvDuration:
                         ctx->data.duration = *(double*)prop->data;
                         notifyDuration(ctx);
@@ -585,6 +597,11 @@ float OFS_Videoplayer::Fps() const noexcept
 bool OFS_Videoplayer::VideoLoaded() const noexcept
 {
     return CTX->data.videoLoaded;
+}
+
+bool OFS_Videoplayer::HasAudio() const noexcept
+{
+    return CTX->data.hasAudio;
 }
 
 float OFS_Videoplayer::CurrentPercentPosition() const noexcept

--- a/README.md
+++ b/README.md
@@ -1,28 +1,49 @@
-# OpenFunscripter
+# OpenFunscripter — 3D Simulator fork
 
-[![Latest Release](https://img.shields.io/github/v/release/Eroscripts/OFS?style=flat-square)](https://github.com/Eroscripts/OFS/releases/latest)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat-square)](https://www.gnu.org/licenses/gpl-3.0)
-[![Downloads](https://img.shields.io/github/downloads/Eroscripts/OFS/total?style=flat-square)](https://github.com/Eroscripts/OFS/releases)
-[![Windows](https://img.shields.io/badge/Windows-0078D6?style=flat-square&logo=windows&logoColor=white)](https://github.com/Eroscripts/OFS/releases/latest)
-[![Linux](https://img.shields.io/badge/Linux-FCC624?style=flat-square&logo=linux&logoColor=black)](https://github.com/Eroscripts/OFS/releases/latest)
-[![macOS](https://img.shields.io/badge/macOS-000000?style=flat-square&logo=apple&logoColor=white)](https://github.com/Eroscripts/OFS/releases/latest)
+[![Latest Release](https://img.shields.io/github/v/release/SaekoM/OFS?style=flat-square)](https://github.com/SaekoM/OFS/releases/latest)
+[![Downloads](https://img.shields.io/github/downloads/SaekoM/OFS/total?style=flat-square)](https://github.com/SaekoM/OFS/releases)
+[![Windows](https://img.shields.io/badge/Windows-0078D6?style=flat-square&logo=windows&logoColor=white)](https://github.com/SaekoM/OFS/releases/latest)
+[![Linux](https://img.shields.io/badge/Linux-FCC624?style=flat-square&logo=linux&logoColor=black)](https://github.com/SaekoM/OFS/releases/latest)
+[![macOS](https://img.shields.io/badge/macOS-000000?style=flat-square&logo=apple&logoColor=white)](https://github.com/SaekoM/OFS/releases/latest)
 
-Can be used to create `.funscript` files. (NSFW)  
-The project is based on OpenGL, SDL2, ImGui, libmpv, & all these other great [libraries](https://github.com/Eroscripts/OFS/tree/master/lib).
+A fork of [OpenFunscripter](https://github.com/Eroscripts/OFS) for authoring `.funscript` files (NSFW), adding a **native 3D multi-axis simulator** and an **animated preview exporter**. Built on OpenGL, SDL2, ImGui, libmpv, and [these libraries](./lib).
 
-### V4 Features
+## Fork features
 
-- **Updated color scheme** — Match ES heatmap coloring
-- **Funscript 2.0 & 1.1 format support** — Full read/write support for the latest funscript specifications
+### 3D multi-axis simulator
+- Visualizes the **main stroke plus surge / sway / twist / roll / pitch** on a 3D device (stroker cylinder, opposing twist markers, optional tongue and center indicator).
+- Axis mapping follows the **TCode** convention, with **device presets** (All axes / SR6 / OSR2+) that restrict axes to real hardware and label channels (L0–L2, R0–R2).
+- **GPU-lit rendering** with orbit camera, per-part colors, an axis gizmo, and a ground grid.
+- **Stroke-length line** — a rod from a fixed ground anchor to the cylinder that tilts and stretches with the device, so you can read the travel at a glance.
+- **Overlay mode** — detach the simulator into a borderless, movable/resizable window over the video.
+
+### Animated preview export
+- Export a **timestamp range** (or a **chapter** from its right-click menu) to **animated WebP** or **AV1 (mp4)**.
+- Optionally **composite the simulator onto the video** — either the 3D device or a flat **2D stroke bar** (which reuses your 2D-simulator colors, height lines, and indicators) — positioned with a **draggable live preview**.
+- Configurable **resolution / fps / quality**, source **audio** for AV1, and supersampled sim rendering to keep files small.
+
+### Quality-of-life
+- **Lua plugin compatibility fixes** — tolerant marshalling for `Checkbox`, `SliderInt`, `InputInt`, `DragInt`.
+- **Shift + 1…0** keybinds for the intermediate positions **5, 15, … 95**.
+
+## From upstream (V4)
+- Updated color scheme to match ES heatmap coloring.
+- Funscript 2.0 & 1.1 format support (full read/write).
 
 ![Speed map](./data/speed-map.png)
 
 ![OpenFunscripter Screenshot](./OpenFunscripter.jpg)
 
-### How to build ( for people who want to contribute or fork )
+## Building (contributors / forkers)
 1. Clone the repository
-2. `cd "OpenFunscripter"`
+2. `cd OFS`
 3. `git submodule update --init`
 4. Run CMake and compile
 
-Known linux dependencies to just compile are `build-essential libmpv-dev libglvnd-dev`.  
+Known Linux build dependencies: `build-essential libmpv-dev libglvnd-dev`.
+
+> **AV1 export note:** the animated preview exporter uses `libsvtav1`, which is only in the ffmpeg **"full"** build (not "essentials"). OFS downloads the full build on first use.
+
+## Credits
+Fork of [OpenFunscripter](https://github.com/Eroscripts/OFS) (Eroscripts), originally by [OpenFunscripter/OFS](https://github.com/OpenFunscripter/OFS). GPLv3.

--- a/localization/localization.csv
+++ b/localization/localization.csv
@@ -212,6 +212,16 @@ ACTION_ACTION_70,Action at 70,Action at 70
 ACTION_ACTION_80,Action at 80,Action at 80
 ACTION_ACTION_90,Action at 90,Action at 90
 ACTION_ACTION_100,Action at 100,Action at 100
+ACTION_ACTION_5,Action at 5,Action at 5
+ACTION_ACTION_15,Action at 15,Action at 15
+ACTION_ACTION_25,Action at 25,Action at 25
+ACTION_ACTION_35,Action at 35,Action at 35
+ACTION_ACTION_45,Action at 45,Action at 45
+ACTION_ACTION_55,Action at 55,Action at 55
+ACTION_ACTION_65,Action at 65,Action at 65
+ACTION_ACTION_75,Action at 75,Action at 75
+ACTION_ACTION_85,Action at 85,Action at 85
+ACTION_ACTION_95,Action at 95,Action at 95
 ACTION_SAVE_PROJECT,Save project,Save project
 ACTION_QUICK_EXPORT,Quick export,Quick export
 ACTION_QUICK_EXPORT_2_0,Quick export (2.0),Quick export (2.0)
@@ -472,6 +482,7 @@ SHOW_POSITION,Show position,Show position
 VANILLA_TOOLTIP,The original simulator from day one.,The original simulator from day one.
 RESET_TO_DEFAULTS,Reset to defaults,Reset to defaults
 SIMULATOR,Simulator,Simulator
+SIMULATOR_3D,3D Simulator,3D Simulator
 APPLICATION,Application,Application
 DARK_MODE,Dark mode,Dark mode
 LIGHT_MODE,Light mode,Light mode

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ set(OPEN_FUNSCRIPTER_SOURCES
   "UI/OFS_ScriptSimulator.cpp"
   "UI/OFS_Simulator3D.cpp"
   "UI/OFS_PreviewExporter.cpp"
+  "UI/OFS_TimelineRasterizer.cpp"
   "UI/OFS_SpecialFunctions.cpp"
   "UI/OFS_ScriptPositionsOverlays.cpp"
   "UI/OFS_DownloadFfmpeg.cpp"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,8 @@ set(OPEN_FUNSCRIPTER_SOURCES
 
   "UI/OFS_Preferences.cpp"
   "UI/OFS_ScriptSimulator.cpp"
+  "UI/OFS_Simulator3D.cpp"
+  "UI/OFS_PreviewExporter.cpp"
   "UI/OFS_SpecialFunctions.cpp"
   "UI/OFS_ScriptPositionsOverlays.cpp"
   "UI/OFS_DownloadFfmpeg.cpp"

--- a/src/OpenFunscripter.cpp
+++ b/src/OpenFunscripter.cpp
@@ -262,6 +262,9 @@ bool OpenFunscripter::Init(int argc, char* argv[])
     controllerInput = std::make_unique<ControllerInput>();
     controllerInput->Init();
     simulator.Init();
+    simulator3D.Init();
+    previewExporter = std::make_unique<OFS_PreviewExporter>();
+    previewExporter->Init();
 
     FunscriptHeatmap::Init();
     extensions = std::make_unique<OFS_LuaExtensions>();
@@ -339,6 +342,7 @@ void OpenFunscripter::setupDefaultLayout(bool force) noexcept
         ImGui::DockBuilderDockWindow(ScriptTimeline::WindowId, dock_positions_id);
         ImGui::DockBuilderDockWindow(ScriptingMode::WindowId, dock_mode_right_id);
         ImGui::DockBuilderDockWindow(ScriptSimulator::WindowId, dock_simulator_right_id);
+        ImGui::DockBuilderDockWindow(Simulator3D::WindowId, dock_simulator_right_id);
         ImGui::DockBuilderDockWindow(ActionEditorWindowId, dock_action_right_id);
         ImGui::DockBuilderDockWindow(StatisticsWindowId, dock_stats_right_id);
         ImGui::DockBuilderDockWindow(UndoSystem::WindowId, dock_undo_right_id);
@@ -436,6 +440,27 @@ void OpenFunscripter::registerBindings()
             {
                 { ImGuiMod_None, ImGuiKey_KeypadDivide },
             });
+        // Intermediate positions (5, 15, .. 95) on Shift + number row.
+        keys->RegisterAction({ "action_5", [this]() { addEditAction(5); } },
+            Tr::ACTION_ACTION_5, "Actions", { { ImGuiMod_Shift, ImGuiKey_1 } });
+        keys->RegisterAction({ "action_15", [this]() { addEditAction(15); } },
+            Tr::ACTION_ACTION_15, "Actions", { { ImGuiMod_Shift, ImGuiKey_2 } });
+        keys->RegisterAction({ "action_25", [this]() { addEditAction(25); } },
+            Tr::ACTION_ACTION_25, "Actions", { { ImGuiMod_Shift, ImGuiKey_3 } });
+        keys->RegisterAction({ "action_35", [this]() { addEditAction(35); } },
+            Tr::ACTION_ACTION_35, "Actions", { { ImGuiMod_Shift, ImGuiKey_4 } });
+        keys->RegisterAction({ "action_45", [this]() { addEditAction(45); } },
+            Tr::ACTION_ACTION_45, "Actions", { { ImGuiMod_Shift, ImGuiKey_5 } });
+        keys->RegisterAction({ "action_55", [this]() { addEditAction(55); } },
+            Tr::ACTION_ACTION_55, "Actions", { { ImGuiMod_Shift, ImGuiKey_6 } });
+        keys->RegisterAction({ "action_65", [this]() { addEditAction(65); } },
+            Tr::ACTION_ACTION_65, "Actions", { { ImGuiMod_Shift, ImGuiKey_7 } });
+        keys->RegisterAction({ "action_75", [this]() { addEditAction(75); } },
+            Tr::ACTION_ACTION_75, "Actions", { { ImGuiMod_Shift, ImGuiKey_8 } });
+        keys->RegisterAction({ "action_85", [this]() { addEditAction(85); } },
+            Tr::ACTION_ACTION_85, "Actions", { { ImGuiMod_Shift, ImGuiKey_9 } });
+        keys->RegisterAction({ "action_95", [this]() { addEditAction(95); } },
+            Tr::ACTION_ACTION_95, "Actions", { { ImGuiMod_Shift, ImGuiKey_0 } });
     }
 
     keys->RegisterGroup("Core", Tr::CORE_BINDING_GROUP);
@@ -1601,6 +1626,8 @@ void OpenFunscripter::Step() noexcept
             specialFunctions->ShowFunctionsWindow(&ofsState.showSpecialFunctions);
             undoSystem->ShowUndoRedoHistory(&ofsState.showHistory);
             simulator.ShowSimulator(&ofsState.showSimulator, ActiveFunscript(), player->CurrentTime(), overlayState.SplineMode);
+            simulator3D.ShowWindow(&ofsState.showSimulator3D, LoadedFunscripts(), player->CurrentTime());
+            previewExporter->ShowWindow(&ShowPreviewExporter);
 
             if (ShowMetadataEditor) {
                 auto& projectState = LoadedProject->State();
@@ -2501,6 +2528,8 @@ void OpenFunscripter::ShowMainMenuBar() noexcept
             if (ImGui::MenuItem(TR(STATISTICS), NULL, &ofsState.showStatistics)) {}
             if (ImGui::MenuItem(TR(UNDO_REDO_HISTORY), NULL, &ofsState.showHistory)) {}
             if (ImGui::MenuItem(TR(SIMULATOR), NULL, &ofsState.showSimulator)) {}
+            if (ImGui::MenuItem(TR(SIMULATOR_3D), NULL, &ofsState.showSimulator3D)) {}
+            if (ImGui::MenuItem("Animated Preview Export", NULL, &ShowPreviewExporter)) {}
             if (ImGui::MenuItem(TR(METADATA), NULL, &ShowMetadataEditor)) {}
             if (ImGui::MenuItem(TR(ACTION_EDITOR), NULL, &ofsState.showActionEditor)) {}
             if (ImGui::MenuItem(TR(SPECIAL_FUNCTIONS), NULL, &ofsState.showSpecialFunctions)) {}

--- a/src/OpenFunscripter.cpp
+++ b/src/OpenFunscripter.cpp
@@ -10,6 +10,7 @@
 #include "OFS_Localization.h"
 
 #include "state/OpenFunscripterState.h"
+#include "state/MetadataEditorState.h"
 #include "state/states/VideoplayerWindowState.h"
 #include "state/states/BaseOverlayState.h"
 #include "state/states/ChapterState.h"
@@ -1859,6 +1860,12 @@ void OpenFunscripter::initProject() noexcept
     if (LoadedProject->IsValid()) {
         auto& projectState = LoadedProject->State();
         if (projectState.nudgeMetadata) {
+            // Apply saved default metadata template to new projects (keep detected duration).
+            auto& metaState = FunscriptMetadataState::State(metadataEditor->StateHandle());
+            auto savedDuration = projectState.metadata.duration;
+            projectState.metadata = metaState.defaultMetadata;
+            projectState.metadata.duration = savedDuration;
+
             const auto& prefState = PreferenceState::State(preferences->StateHandle());
             ShowMetadataEditor = prefState.showMetaOnNew;
             projectState.nudgeMetadata = false;
@@ -2216,15 +2223,20 @@ void OpenFunscripter::ShowMainMenuBar() noexcept
                     ImGui::TextDisabled("%s", TR(NO_RECENT_FILES));
                 }
                 auto& recentFiles = ofsState.recentFiles;
-                for (auto it = recentFiles.rbegin(); it != recentFiles.rend(); ++it) {
+                int recentIdx = 0;
+                for (auto it = recentFiles.rbegin(); it != recentFiles.rend(); ++it, ++recentIdx) {
                     auto& recent = *it;
-                    if (ImGui::MenuItem(recent.name.c_str())) {
-                        if (!recent.projectPath.empty()) {
-                            closeWithoutSavingDialog([this, clickedFile = recent.projectPath]() {
-                                openFile(clickedFile);
-                            });
-                            break;
-                        }
+                    // recent.name can be empty (a stored path with no filename). Seed the
+                    // widget ID from the index and give a fallback label so ImGui never
+                    // gets an empty ID (which asserts at the root of the menu popup).
+                    ImGui::PushID(recentIdx);
+                    const bool clicked = ImGui::MenuItem(recent.name.empty() ? "(unnamed)" : recent.name.c_str());
+                    ImGui::PopID();
+                    if (clicked && !recent.projectPath.empty()) {
+                        closeWithoutSavingDialog([this, clickedFile = recent.projectPath]() {
+                            openFile(clickedFile);
+                        });
+                        break;
                     }
                 }
                 ImGui::Separator();
@@ -2309,22 +2321,31 @@ void OpenFunscripter::ShowMainMenuBar() noexcept
                         });
                     return it != app->LoadedFunscripts().end();
                 };
-                auto addNewShortcut = [this, fileAlreadyLoaded](const char* axisExt) noexcept {
-                    if (ImGui::MenuItem(axisExt)) {
-                        std::string newScriptPath;
-                        {
-                            auto root = Util::PathFromString(
-                                LoadedProject->MakePathAbsolute(LoadedFunscripts()[0]->RelativePath()));
-                            root.replace_extension(Util::Format(".%s.funscript", axisExt));
-                            newScriptPath = root.u8string();
-                        }
+                auto addAxisScript = [this, fileAlreadyLoaded](const char* axisExt) noexcept {
+                    std::string newScriptPath;
+                    {
+                        auto root = Util::PathFromString(
+                            LoadedProject->MakePathAbsolute(LoadedFunscripts()[0]->RelativePath()));
+                        root.replace_extension(Util::Format(".%s.funscript", axisExt));
+                        newScriptPath = root.u8string();
+                    }
 
-                        if (!fileAlreadyLoaded(newScriptPath)) {
-                            LoadedProject->AddFunscript(newScriptPath);
-                        }
+                    if (!fileAlreadyLoaded(newScriptPath)) {
+                        LoadedProject->AddFunscript(newScriptPath);
+                    }
+                };
+                auto addNewShortcut = [addAxisScript](const char* axisExt) noexcept {
+                    if (ImGui::MenuItem(axisExt)) {
+                        addAxisScript(axisExt);
                     }
                 };
                 if (ImGui::BeginMenu(TR(ADD_SHORTCUTS))) {
+                    // The five positional axes at once (skips any already loaded).
+                    static const char* multiAxes[] = { "surge", "sway", "twist", "roll", "pitch" };
+                    if (ImGui::MenuItem("All (surge, sway, twist, roll, pitch)")) {
+                        for (auto axis : multiAxes) addAxisScript(axis);
+                    }
+                    ImGui::Separator();
                     for (auto axis : Funscript::AxisNames) {
                         addNewShortcut(axis);
                     }

--- a/src/OpenFunscripter.cpp
+++ b/src/OpenFunscripter.cpp
@@ -257,6 +257,8 @@ bool OpenFunscripter::Init(int argc, char* argv[])
         ShouldChangeActiveScriptEvent::HandleEvent(EVENT_SYSTEM_BIND(this, &OpenFunscripter::ScriptTimelineActiveScriptChanged)));
     EV::Queue().appendListener(ExportClipForChapter::EventType,
         ExportClipForChapter::HandleEvent(EVENT_SYSTEM_BIND(this, &OpenFunscripter::ExportClip)));
+    EV::Queue().appendListener(ExportPreviewForChapter::EventType,
+        ExportPreviewForChapter::HandleEvent(EVENT_SYSTEM_BIND(this, &OpenFunscripter::ExportPreview)));
 
     specialFunctions = std::make_unique<SpecialFunctionsWindow>();
     controllerInput = std::make_unique<ControllerInput>();
@@ -1393,6 +1395,12 @@ void OpenFunscripter::ExportClip(const ExportClipForChapter* ev) noexcept
         });
 }
 
+void OpenFunscripter::ExportPreview(const ExportPreviewForChapter* ev) noexcept
+{
+    previewExporter->OpenForChapter(ev->chapter.startTime, ev->chapter.endTime);
+    ShowPreviewExporter = true;
+}
+
 void OpenFunscripter::FunscriptChanged(const FunscriptActionsChangedEvent* ev) noexcept
 {
     // the event passes the address of the Funscript
@@ -1627,6 +1635,7 @@ void OpenFunscripter::Step() noexcept
             undoSystem->ShowUndoRedoHistory(&ofsState.showHistory);
             simulator.ShowSimulator(&ofsState.showSimulator, ActiveFunscript(), player->CurrentTime(), overlayState.SplineMode);
             simulator3D.ShowWindow(&ofsState.showSimulator3D, LoadedFunscripts(), player->CurrentTime());
+            previewExporter->Update();
             previewExporter->ShowWindow(&ShowPreviewExporter);
 
             if (ShowMetadataEditor) {

--- a/src/OpenFunscripter.h
+++ b/src/OpenFunscripter.h
@@ -73,6 +73,7 @@ private:
     void processEvents() noexcept;
 
     void ExportClip(const class ExportClipForChapter* ev) noexcept;
+    void ExportPreview(const class ExportPreviewForChapter* ev) noexcept;
 
     void FunscriptChanged(const FunscriptActionsChangedEvent* ev) noexcept;
     void DragNDrop(const OFS_SDL_Event* ev) noexcept;

--- a/src/OpenFunscripter.h
+++ b/src/OpenFunscripter.h
@@ -6,6 +6,8 @@
 #include "OFS_UndoSystem.h"
 #include "OFS_EventSystem.h"
 #include "OFS_ScriptSimulator.h"
+#include "OFS_Simulator3D.h"
+#include "OFS_PreviewExporter.h"
 #include "OFS_ControllerInput.h"
 #include "GradientBar.h"
 #include "OFS_SpecialFunctions.h"
@@ -42,6 +44,7 @@ private:
 
     uint32_t stateHandle = 0xFFFF'FFFF;
     bool ShowMetadataEditor = false;
+    bool ShowPreviewExporter = false;
     bool ShowProjectEditor = false;
 #ifndef NDEBUG
     bool DebugDemo = false;
@@ -140,6 +143,7 @@ public:
     ScriptTimeline scriptTimeline;
     OFS_VideoplayerControls playerControls;
     ScriptSimulator simulator;
+    Simulator3D simulator3D;
     OFS_BlockingTask blockingTask;
 
     std::unique_ptr<OFS_Videoplayer> player;
@@ -154,6 +158,7 @@ public:
     std::unique_ptr<OFS_FunscriptMetadataEditor> metadataEditor;
     std::unique_ptr<OFS_WebsocketApi> webApi;
     std::unique_ptr<OFS_ChapterManager> chapterMgr;
+    std::unique_ptr<OFS_PreviewExporter> previewExporter;
 
     std::unique_ptr<OFS_Project> LoadedProject;
 
@@ -171,6 +176,8 @@ public:
     {
         return LoadedProject->ActiveScript();
     }
+
+    inline Simulator3D& GetSimulator3D() noexcept { return simulator3D; }
 
     void UpdateNewActiveScript(uint32_t activeIndex) noexcept;
 

--- a/src/UI/OFS_DownloadFfmpeg.cpp
+++ b/src/UI/OFS_DownloadFfmpeg.cpp
@@ -106,7 +106,8 @@ void OFS_DownloadFfmpeg::DownloadFfmpegModal() noexcept
                 auto dlThread = [](void* data) -> int {
                     auto path = Util::PathFromString(Util::Prefpath());
                     auto downloadPath =(path / "ffmpeg.zip").wstring();
-                    URLDownloadToFileW(NULL, L"https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip",
+                    // "full" build (not "essentials") so encoders like libsvtav1 are available.
+                    URLDownloadToFileW(NULL, L"https://www.gyan.dev/ffmpeg/builds/ffmpeg-git-full.7z",
                         downloadPath.c_str(), 0, &cb);
                     return 0;
                 };

--- a/src/UI/OFS_Preferences.cpp
+++ b/src/UI/OFS_Preferences.cpp
@@ -10,12 +10,95 @@
 #include "OFS_Reflection.h"
 #include "OFS_StateHandle.h"
 #include "state/states/BaseOverlayState.h"
+#include "state/LineColorState.h"
+#include "FunscriptHeatmap.h"
+
+#include <algorithm>
 
 OFS_Preferences::OFS_Preferences() noexcept
 {
 	prefStateHandle = OFS_AppState<PreferenceState>::Register(PreferenceState::StateName);
+	lineColorStateHandle = OFS_AppState<LineColorState>::Register(LineColorState::StateName);
 	auto& state = PreferenceState::State(prefStateHandle);
     OFS_DynFontAtlas::FontOverride = state.fontOverride;
+    ApplyLineColors(); // honor the persisted line-color profile from startup
+}
+
+void OFS_Preferences::ApplyLineColors() noexcept
+{
+	auto& lc = LineColorState::State(lineColorStateHandle);
+	if (lc.profile == FunscriptHeatmap::Custom) {
+		std::vector<std::pair<float, ImU32>> stops;
+		stops.reserve(lc.customStops.size());
+		for (auto& s : lc.customStops) stops.emplace_back(s.pos, s.color);
+		std::sort(stops.begin(), stops.end(), [](auto& a, auto& b) { return a.first < b.first; });
+		if (stops.empty()) stops = FunscriptHeatmap::LinePreset(FunscriptHeatmap::Fork);
+		FunscriptHeatmap::SetLineColors(stops);
+	} else {
+		FunscriptHeatmap::SetLineColors(FunscriptHeatmap::LinePreset(lc.profile));
+	}
+}
+
+// Profile picker + (for Custom) a stop editor. Returns true when the palette changes.
+bool OFS_Preferences::drawLineColorEditor() noexcept
+{
+	auto& lc = LineColorState::State(lineColorStateHandle);
+	bool changed = false;
+
+	if (ImGui::Combo("Profile##LineColorProfile", &lc.profile, "Fork\0Classic (OFS)\0Custom\0\0")) {
+		if (lc.profile == FunscriptHeatmap::Custom && lc.customStops.empty()) {
+			// Seed the custom palette from the fork preset on first use.
+			for (auto& s : FunscriptHeatmap::LinePreset(FunscriptHeatmap::Fork))
+				lc.customStops.push_back({ s.first, s.second });
+		}
+		changed = true;
+	}
+
+	// Live gradient preview.
+	ImGradient::DrawGradientBar(&FunscriptHeatmap::LineColors,
+		ImGui::GetCursorScreenPos(), ImGui::GetContentRegionAvail().x, 20.f);
+	ImGui::Dummy(ImVec2(ImGui::GetContentRegionAvail().x, 24.f));
+
+	if (lc.profile == FunscriptHeatmap::Custom) {
+		int removeAt = -1;
+		for (int i = 0; i < (int)lc.customStops.size(); ++i) {
+			ImGui::PushID(i);
+			auto& stop = lc.customStops[i];
+			ImGui::SetNextItemWidth(120.f);
+			if (ImGui::DragFloat("##pos", &stop.pos, 0.005f, 0.f, 1.f, "%.3f")) {
+				stop.pos = Util::Clamp(stop.pos, 0.f, 1.f); changed = true;
+			}
+			ImGui::SameLine();
+			ImVec4 col = ImGui::ColorConvertU32ToFloat4(stop.color);
+			if (ImGui::ColorEdit4("##col", &col.x, ImGuiColorEditFlags_NoInputs | ImGuiColorEditFlags_AlphaPreview)) {
+				stop.color = ImGui::ColorConvertFloat4ToU32(col); changed = true;
+			}
+			ImGui::SameLine();
+			if (ImGui::SmallButton("X")) removeAt = i;
+			ImGui::PopID();
+		}
+		if (removeAt >= 0 && lc.customStops.size() > 1) { lc.customStops.erase(lc.customStops.begin() + removeAt); changed = true; }
+
+		if (ImGui::Button("Add stop")) {
+			lc.customStops.push_back({ 1.f, IM_COL32_WHITE });
+			changed = true;
+		}
+		ImGui::SameLine();
+		if (ImGui::Button("Reset to Fork")) {
+			lc.customStops.clear();
+			for (auto& s : FunscriptHeatmap::LinePreset(FunscriptHeatmap::Fork)) lc.customStops.push_back({ s.first, s.second });
+			changed = true;
+		}
+		ImGui::SameLine();
+		if (ImGui::Button("Reset to Classic")) {
+			lc.customStops.clear();
+			for (auto& s : FunscriptHeatmap::LinePreset(FunscriptHeatmap::Classic)) lc.customStops.push_back({ s.first, s.second });
+			changed = true;
+		}
+	}
+
+	if (changed) ApplyLineColors();
+	return changed;
 }
 
 static void copyTranslationHelper() noexcept
@@ -192,6 +275,11 @@ bool OFS_Preferences::ShowPreferenceWindow() noexcept
 					OFS::Tooltip(TR(FAST_FRAME_STEP_TOOLTIP));
 					ImGui::Separator();
 					if (ImGui::Checkbox(TR(SHOW_METADATA_DIALOG_ON_NEW_PROJECT), &state.showMetaOnNew)) {
+						save = true;
+					}
+					ImGui::Separator();
+					ImGui::TextDisabled("Action line colors (by speed)");
+					if (drawLineColorEditor()) {
 						save = true;
 					}
 					ImGui::EndTabItem();

--- a/src/UI/OFS_Preferences.h
+++ b/src/UI/OFS_Preferences.h
@@ -20,9 +20,14 @@ class OFS_Preferences
 {
 private:
 	uint32_t prefStateHandle = 0xFFFF'FFFF;
+	uint32_t lineColorStateHandle = 0xFFFF'FFFF;
 	std::vector<std::string> translationFiles;
+
+	bool drawLineColorEditor() noexcept; // returns true if the palette changed
 public:
 	inline uint32_t StateHandle() const noexcept { return prefStateHandle; }
+	// Rebuild the action-line gradient from the persisted LineColorState.
+	void ApplyLineColors() noexcept;
 public:
 	bool ShowWindow = false;
 	OFS_Preferences() noexcept;

--- a/src/UI/OFS_PreviewExporter.cpp
+++ b/src/UI/OFS_PreviewExporter.cpp
@@ -192,13 +192,18 @@ void OFS_PreviewExporter::OpenForChapter(float start, float end) noexcept
     endEditing = false;
 }
 
-void OFS_PreviewExporter::startExport(const std::string& outputPath, float start, float end) noexcept
+void OFS_PreviewExporter::startExport(const std::string& outputPath, const std::vector<Segment>& segments) noexcept
 {
     if (exporting.load() || renderingFrames) return;
+    if (segments.empty()) return;
+    for (auto& s : segments) if (s.dur <= 0.f) return;
     auto& st = PreviewExportState::State(stateHandle);
     auto app = OpenFunscripter::ptr;
     const char* videoPath = app->player->VideoPath();
-    if (!videoPath || !*videoPath || end <= start) return;
+    if (!videoPath || !*videoPath) return;
+
+    const int N = (int)segments.size();
+    const bool compilation = N > 1;   // several slices concatenated
 
     const int outH = st.resolution; // height of the video region
     const uint16_t vw = app->player->VideoWidth();
@@ -212,7 +217,8 @@ void OFS_PreviewExporter::startExport(const std::string& outputPath, float start
     const bool doSim = st.overlaySim && haveScript;
     const bool doTimeline = st.overlayTimeline && haveScript;
     const bool needFrames = doSim || doTimeline;
-    const bool useFC = needFrames || st.padTo169; // needs -filter_complex
+    const bool useFC = needFrames || st.padTo169 || compilation; // needs -filter_complex
+    const bool wantAudio = (st.format == 1) && app->player->HasAudio(); // AV1 carries audio
 
     // Timeline strip band height (extends the canvas below the video region).
     int bandH = 0;
@@ -252,16 +258,18 @@ void OFS_PreviewExporter::startExport(const std::string& outputPath, float start
     a.push_back("-y");
     a.push_back("-hide_banner");
     a.push_back("-loglevel"); a.push_back("error");
-    // -ss and -t must both be INPUT options on the video (before -i). When extra
-    // overlay inputs follow, a -t placed after -i video would bind to those inputs
-    // instead of trimming the video -> the whole clip would export.
-    stbsp_snprintf(buf, sizeof(buf), "%.3f", start);       a.push_back("-ss"); a.push_back(buf);
-    stbsp_snprintf(buf, sizeof(buf), "%.3f", end - start); a.push_back("-t"); a.push_back(buf);
-    a.push_back("-i"); a.push_back(videoPath);
+    // One fast-seeked video input per segment. -ss and -t must both be INPUT options
+    // (before -i); a -t after -i would bind to a following input instead of trimming.
+    for (auto& s : segments) {
+        stbsp_snprintf(buf, sizeof(buf), "%.3f", s.start); a.push_back("-ss"); a.push_back(buf);
+        stbsp_snprintf(buf, sizeof(buf), "%.3f", s.dur);   a.push_back("-t");  a.push_back(buf);
+        a.push_back("-i"); a.push_back(videoPath);
+    }
 
     if (useFC) {
-        // Add a framerate-tagged image-sequence input for each overlay layer.
-        int simInput = -1, tlInput = -1, nextInput = 1;
+        // Add a framerate-tagged image-sequence input for each overlay layer (after
+        // the N video inputs, so overlay input indices start at N).
+        int simInput = -1, tlInput = -1, nextInput = N;
         for (auto& L : layers) {
             stbsp_snprintf(buf, sizeof(buf), "%d", st.fps); a.push_back("-framerate"); a.push_back(buf);
             a.push_back("-i");
@@ -270,8 +278,16 @@ void OFS_PreviewExporter::startExport(const std::string& outputPath, float start
             ++nextInput;
         }
 
-        // Base: fps -> scale (optionally 16:9 pillarbox) -> optionally extend canvas below.
-        std::string fg = "[0:v]fps=" + std::to_string(st.fps) + ",";
+        // Concatenate the segment videos first (compilation), then fps/scale/pad.
+        std::string fg;
+        std::string base = "[0:v]";
+        if (compilation) {
+            for (int i = 0; i < N; ++i) { stbsp_snprintf(buf, sizeof(buf), "[%d:v]", i); fg += buf; }
+            stbsp_snprintf(buf, sizeof(buf), "concat=n=%d:v=1[cat];", N); fg += buf;
+            base = "[cat]";
+        }
+        fg += base;
+        fg += "fps=" + std::to_string(st.fps) + ",";
         if (st.padTo169) {
             stbsp_snprintf(buf, sizeof(buf),
                 "scale=%d:%d:force_original_aspect_ratio=decrease,pad=%d:%d:(ow-iw)/2:(oh-ih)/2:black",
@@ -291,10 +307,21 @@ void OFS_PreviewExporter::startExport(const std::string& outputPath, float start
             stbsp_snprintf(buf, sizeof(buf), ";%s[%d:v]overlay=0:%d[outv]", last.c_str(), tlInput, outH);
             fg += buf; last = "[outv]";
         }
+        // Audio (AV1 only): concat each segment's audio for a compilation, else map source.
+        std::string audioLabel;
+        if (wantAudio && compilation) {
+            fg += ";";
+            for (int i = 0; i < N; ++i) { stbsp_snprintf(buf, sizeof(buf), "[%d:a]", i); fg += buf; }
+            stbsp_snprintf(buf, sizeof(buf), "concat=n=%d:v=0:a=1[outa]", N); fg += buf;
+            audioLabel = "[outa]";
+        }
         a.push_back("-filter_complex"); a.push_back(fg);
         // filter_complex disables auto stream selection, so map explicitly.
         a.push_back("-map"); a.push_back(last);
-        if (st.format == 1) { a.push_back("-map"); a.push_back("0:a?"); } // source audio for AV1
+        if (wantAudio) {
+            a.push_back("-map");
+            a.push_back(compilation ? audioLabel : std::string("0:a?"));
+        }
     } else {
         stbsp_snprintf(buf, sizeof(buf), "fps=%d", st.fps);
         a.push_back("-filter:v"); a.push_back(buf);
@@ -325,12 +352,15 @@ void OFS_PreviewExporter::startExport(const std::string& outputPath, float start
 
     if (needFrames) {
         // Kick off the incremental frame-render job; ffmpeg spawns when it finishes.
-        int frames = (int)std::lround((double)(end - start) * st.fps);
-        if (frames < 1) frames = 1;
+        // Segments share one duration, so frames-per-segment is uniform.
+        int framesPerSeg = (int)std::lround((double)segments[0].dur * st.fps);
+        if (framesPerSeg < 1) framesPerSeg = 1;
         jobFrame = 0;
-        jobFrameCount = frames;
-        jobStart = start;
+        jobFramesPerSeg = framesPerSeg;
+        jobFrameCount = framesPerSeg * N;
         jobFps = (float)st.fps;
+        jobSegStarts.clear();
+        for (auto& s : segments) jobSegStarts.push_back(s.start);
         jobLayers = std::move(layers);
         jobArgs = std::move(a);
         renderingFrames = true;
@@ -355,7 +385,11 @@ void OFS_PreviewExporter::Update() noexcept
     constexpr int kBatch = 4;
     std::vector<uint8_t> textOverlay; // reused scratch for baked height text
     for (int k = 0; k < kBatch && jobFrame < jobFrameCount; ++k, ++jobFrame) {
-        const float t = jobStart + (float)jobFrame / jobFps;
+        // Output frame -> source time within its segment (segments are concatenated).
+        int seg = jobFramesPerSeg > 0 ? (jobFrame / jobFramesPerSeg) : 0;
+        if (seg >= (int)jobSegStarts.size()) seg = (int)jobSegStarts.size() - 1;
+        const int localFrame = jobFrame - seg * jobFramesPerSeg;
+        const float t = jobSegStarts[seg] + (float)localFrame / jobFps;
         char name[48];
         for (auto& L : jobLayers) {
             bool ok = true;
@@ -470,7 +504,22 @@ void OFS_PreviewExporter::ShowWindow(bool* open) noexcept
     timeField("End (h:m:s.ms)", endTime, endStr, endEditing);
     const float rStart = startTime;
     const float rEnd = endTime;
-    const bool haveRange = true;
+
+    // ---- Compilation: several slices spread evenly across the whole video ----
+    ImGui::Separator();
+    ImGui::Checkbox("Compilation (slices across the whole video)", &st.compilation);
+    if (st.compilation) {
+        if (ImGui::SliderInt("Slices", &st.compSlices, 2, 30))
+            st.compSlices = Util::Clamp(st.compSlices, 1, 100);
+        if (ImGui::SliderFloat("Slice duration", &st.compSliceDur, 0.5f, 10.f, "%.1f s"))
+            st.compSliceDur = Util::Clamp(st.compSliceDur, 0.1f, 60.f);
+        ImGui::Text("Output length: %.1f s  (%d \xC3\x97 %.1f s)",
+                    st.compSlices * st.compSliceDur, st.compSlices, st.compSliceDur);
+        if ((float)duration > 0.f && st.compSlices * st.compSliceDur > (float)duration)
+            ImGui::TextColored(ImVec4(1.f, 0.6f, 0.3f, 1.f), "Slices exceed the video length \xE2\x80\x94 they will overlap.");
+        ImGui::TextDisabled("Ignores the Start/End range above.");
+    }
+    const bool haveRange = st.compilation ? (duration > 0.0) : (rEnd > rStart);
 
     // ---- Overlay the simulator on the video (draggable live preview) ----
     ImGui::Separator();
@@ -630,16 +679,32 @@ void OFS_PreviewExporter::ShowWindow(bool* open) noexcept
     ImGui::Separator();
     const char* videoPath = app->player->VideoPath();
     const bool busy = exporting.load() || renderingFrames;
-    const bool canExport = !busy && haveRange && rEnd > rStart && videoPath && *videoPath;
+    const bool canExport = !busy && haveRange && videoPath && *videoPath;
 
     ImGui::BeginDisabled(!canExport);
     if (ImGui::Button("Export\xE2\x80\xA6")) {
-        const char* filter = st.format == 0 ? "*.webp" : "*.mp4";
+        // Build the segment list: one slice for a normal export, or N evenly-spread
+        // slices (each centered in its 1/N band of the timeline) for a compilation.
+        std::vector<Segment> segments;
+        if (st.compilation) {
+            const float T = (float)duration;
+            const int n = Util::Clamp(st.compSlices, 1, 100);
+            const float D = Util::Clamp(st.compSliceDur, 0.1f, Util::Max(0.1f, T));
+            const float band = T / (float)n;
+            for (int i = 0; i < n; ++i) {
+                float s = (float)i * band + (band - D) * 0.5f;
+                s = Util::Clamp(s, 0.f, Util::Max(0.f, T - D));
+                segments.push_back({ s, D });
+            }
+        } else {
+            segments.push_back({ rStart, rEnd - rStart });
+        }
         const char* ext = st.format == 0 ? ".webp" : ".mp4";
-        std::string defaultName = std::string("preview") + ext;
+        const char* filter = st.format == 0 ? "*.webp" : "*.mp4";
+        std::string defaultName = std::string(st.compilation ? "compilation" : "preview") + ext;
         Util::SaveFileDialog("Export animated preview", defaultName,
-            [this, rStart, rEnd](Util::FileDialogResult& result) {
-                if (!result.files.empty()) startExport(result.files[0], rStart, rEnd);
+            [this, segments](Util::FileDialogResult& result) {
+                if (!result.files.empty()) startExport(result.files[0], segments);
             },
             { filter });
     }

--- a/src/UI/OFS_PreviewExporter.cpp
+++ b/src/UI/OFS_PreviewExporter.cpp
@@ -1,0 +1,275 @@
+#include "OFS_PreviewExporter.h"
+#include "state/PreviewExportState.h"
+#include "state/states/ChapterState.h"
+
+#include "OpenFunscripter.h"
+#include "OFS_Simulator3D.h"
+#include "OFS_Util.h"
+
+#include "subprocess.h"
+#include "imgui.h"
+#include "stb_sprintf.h"
+#include "stb_image_write.h"
+
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <thread>
+#include <vector>
+
+void OFS_PreviewExporter::Init() noexcept
+{
+    stateHandle = OFS_AppState<PreviewExportState>::Register(PreviewExportState::StateName);
+}
+
+void OFS_PreviewExporter::beginExport(const std::string& outputPath, float start, float end) noexcept
+{
+    if (exporting.load()) return;
+    auto& st = PreviewExportState::State(stateHandle);
+    auto app = OpenFunscripter::ptr;
+    const char* videoPath = app->player->VideoPath();
+    if (!videoPath || !*videoPath || end <= start) return;
+
+    // Output dimensions: height fixed, width from the video aspect (even).
+    const int outH = st.resolution;
+    const uint16_t vw = app->player->VideoWidth();
+    const uint16_t vh = app->player->VideoHeight();
+    int outW = (vh > 0) ? (int)std::lround((double)vw * outH / (double)vh) : (outH * 16 / 9);
+    outW -= (outW & 1);
+    if (outW < 2) outW = 2;
+
+    // Optionally render the simulator to a transparent PNG sequence (main thread, GL).
+    const bool doOverlay = st.overlaySim && !app->LoadedFunscripts().empty();
+    std::string framePattern, tempDir;
+    int ox = 0, oy = 0;
+    if (doOverlay) {
+        int ow = ((int)std::lround(st.simW * outW)) & ~1; if (ow < 2) ow = 2;
+        int oh = ((int)std::lround(st.simH * outH)) & ~1; if (oh < 2) oh = 2;
+        ox = (int)std::lround(st.simX * outW);
+        oy = (int)std::lround(st.simY * outH);
+
+        tempDir = Util::Prefpath("preview_frames");
+        std::error_code ec;
+        std::filesystem::remove_all(std::filesystem::u8path(tempDir), ec);
+        Util::CreateDirectories(std::filesystem::u8path(tempDir));
+
+        int frames = (int)std::lround((double)(end - start) * st.fps);
+        if (frames < 1) frames = 1;
+
+        auto& sim = app->GetSimulator3D();
+        auto& scripts = app->LoadedFunscripts();
+        std::vector<uint8_t> pixels;
+        for (int i = 0; i < frames; ++i) {
+            const float t = start + (float)i / (float)st.fps;
+            if (!sim.RenderPoseRGBA(scripts, t, ow, oh, pixels)) break;
+            char name[32];
+            stbsp_snprintf(name, sizeof(name), "frame_%05d.png", i);
+            const auto p = (std::filesystem::u8path(tempDir) / name).u8string();
+            stbi_write_png(p.c_str(), ow, oh, 4, pixels.data(), ow * 4);
+        }
+        framePattern = (std::filesystem::u8path(tempDir) / "frame_%05d.png").u8string();
+    }
+
+    const std::string ffmpeg = Util::FfmpegPath().u8string();
+    char buf[160];
+
+    std::vector<std::string> a;
+    a.push_back(ffmpeg);
+    a.push_back("-y");
+    a.push_back("-hide_banner");
+    a.push_back("-loglevel"); a.push_back("error"); // keep stderr small
+    stbsp_snprintf(buf, sizeof(buf), "%.3f", start);       a.push_back("-ss"); a.push_back(buf);
+    a.push_back("-i"); a.push_back(videoPath);
+    stbsp_snprintf(buf, sizeof(buf), "%.3f", end - start); a.push_back("-t"); a.push_back(buf);
+
+    if (doOverlay) {
+        stbsp_snprintf(buf, sizeof(buf), "%d", st.fps); a.push_back("-framerate"); a.push_back(buf);
+        a.push_back("-i"); a.push_back(framePattern);
+        stbsp_snprintf(buf, sizeof(buf), "[0:v]fps=%d,scale=-2:%d[bg];[bg][1:v]overlay=%d:%d",
+                       st.fps, st.resolution, ox, oy);
+        a.push_back("-filter_complex"); a.push_back(buf);
+    } else {
+        stbsp_snprintf(buf, sizeof(buf), "fps=%d,scale=-2:%d:flags=lanczos", st.fps, st.resolution);
+        a.push_back("-vf"); a.push_back(buf);
+    }
+    a.push_back("-an");
+
+    if (st.format == 0) { // animated WebP
+        a.push_back("-c:v"); a.push_back("libwebp");
+        stbsp_snprintf(buf, sizeof(buf), "%d", st.quality); a.push_back("-q:v"); a.push_back(buf);
+        a.push_back("-loop"); a.push_back("0");
+    } else { // AV1 (webm)
+        const int crf = (int)std::lround((100.0 - st.quality) * 0.63); // quality 100->crf 0, 0->63
+        a.push_back("-c:v"); a.push_back("libsvtav1");
+        stbsp_snprintf(buf, sizeof(buf), "%d", crf); a.push_back("-crf"); a.push_back(buf);
+        a.push_back("-b:v"); a.push_back("0");
+    }
+    a.push_back(outputPath);
+
+    exporting.store(true);
+    hasRun = true;
+    std::thread([this, a = std::move(a), tempDir]() mutable {
+        std::vector<const char*> argv;
+        argv.reserve(a.size() + 1);
+        for (auto& s : a) argv.push_back(s.c_str());
+        argv.push_back(nullptr);
+
+        int rc = -1;
+        struct subprocess_s proc;
+        if (subprocess_create(argv.data(), subprocess_option_no_window, &proc) == 0) {
+            if (proc.stdout_file) { fclose(proc.stdout_file); proc.stdout_file = nullptr; }
+            if (proc.stderr_file) { fclose(proc.stderr_file); proc.stderr_file = nullptr; }
+            subprocess_join(&proc, &rc);
+            subprocess_destroy(&proc);
+        }
+        if (!tempDir.empty()) {
+            std::error_code ec;
+            std::filesystem::remove_all(std::filesystem::u8path(tempDir), ec);
+        }
+        lastResult.store(rc);
+        exporting.store(false);
+    }).detach();
+}
+
+void OFS_PreviewExporter::ShowWindow(bool* open) noexcept
+{
+    if (!*open) return;
+    auto& st = PreviewExportState::State(stateHandle);
+    auto app = OpenFunscripter::ptr;
+
+    ImGui::Begin("Animated Preview Export###PREVIEW_EXPORT", open, ImGuiWindowFlags_None);
+
+    ImGui::Combo("Format", &st.format, "Animated WebP\0AV1 (webm)\0\0");
+    if (ImGui::InputInt("Height (px)", &st.resolution)) st.resolution = Util::Clamp(st.resolution, 64, 2160);
+    if (ImGui::InputInt("FPS", &st.fps)) st.fps = Util::Clamp(st.fps, 1, 60);
+    ImGui::SliderInt("Quality", &st.quality, 0, 100);
+
+    ImGui::Separator();
+    ImGui::RadioButton("Chapter", &st.rangeMode, 0);
+    ImGui::SameLine();
+    ImGui::RadioButton("Timestamps", &st.rangeMode, 1);
+
+    const double duration = app->player->Duration();
+    float rStart = 0.f, rEnd = 0.f;
+    bool haveRange = false;
+
+    if (st.rangeMode == 0) {
+        auto& chapters = ChapterState::StaticStateSlow().chapters;
+        if (chapters.empty()) {
+            ImGui::TextDisabled("No chapters \xE2\x80\x94 add chapters or switch to Timestamps.");
+        } else {
+            selectedChapter = Util::Clamp(selectedChapter, 0, (int)chapters.size() - 1);
+            if (ImGui::BeginCombo("Chapter", chapters[selectedChapter].name.c_str())) {
+                for (int i = 0; i < (int)chapters.size(); ++i) {
+                    if (ImGui::Selectable(chapters[i].name.c_str(), i == selectedChapter))
+                        selectedChapter = i;
+                }
+                ImGui::EndCombo();
+            }
+            rStart = chapters[selectedChapter].startTime;
+            rEnd = chapters[selectedChapter].endTime;
+            haveRange = true;
+        }
+    } else {
+        ImGui::InputFloat("Start (s)", &startTime);
+        ImGui::InputFloat("End (s)", &endTime);
+        startTime = Util::Clamp(startTime, 0.f, (float)duration);
+        endTime = Util::Clamp(endTime, 0.f, (float)duration);
+        rStart = startTime;
+        rEnd = endTime;
+        haveRange = true;
+    }
+
+    // ---- Overlay the simulator on the video (draggable live preview) ----
+    ImGui::Separator();
+    ImGui::Checkbox("Overlay simulator on video", &st.overlaySim);
+    if (st.overlaySim) {
+        const uint32_t frameTex = app->player->FrameTexture();
+        const uint16_t vw = app->player->VideoWidth();
+        const uint16_t vh = app->player->VideoHeight();
+        if (frameTex && vw > 0 && vh > 0) {
+            ImGui::TextDisabled("Drag to move \xE2\x80\xA2 drag corner to resize");
+            float previewW = ImGui::GetContentRegionAvail().x;
+            if (previewW > 480.f) previewW = 480.f;
+            const float previewH = previewW * (float)vh / (float)vw;
+            const ImVec2 origin = ImGui::GetCursorScreenPos();
+            ImGui::Image((ImTextureID)(intptr_t)frameTex, ImVec2(previewW, previewH));
+            auto* dl = ImGui::GetWindowDrawList();
+
+            const ImVec2 bMin(origin.x + st.simX * previewW, origin.y + st.simY * previewH);
+            const int bw = (int)(st.simW * previewW);
+            const int bh = (int)(st.simH * previewH);
+            const ImVec2 bMax(bMin.x + bw, bMin.y + bh);
+
+            // Live sim rendered into the box at the current playhead time.
+            if (bw > 4 && bh > 4 && !app->LoadedFunscripts().empty()) {
+                const uint32_t simTex = app->GetSimulator3D().RenderPoseTexture(
+                    app->LoadedFunscripts(), (float)app->player->CurrentTime(), bw, bh);
+                dl->AddImage((ImTextureID)(intptr_t)simTex, bMin, bMax, ImVec2(0, 1), ImVec2(1, 0));
+            }
+            dl->AddRect(bMin, bMax, IM_COL32(0xFF, 0xE0, 0x40, 0xD0), 0.f, 0, 2.f);
+            dl->AddTriangleFilled(ImVec2(bMax.x - 12, bMax.y), bMax, ImVec2(bMax.x, bMax.y - 12),
+                                  IM_COL32(0xFF, 0xE0, 0x40, 0xF0));
+
+            // Move handle (whole box) + resize handle (corner).
+            ImGui::SetCursorScreenPos(bMin);
+            ImGui::InvisibleButton("##simMove", ImVec2((float)bw, (float)bh));
+            ImGui::SetItemAllowOverlap();
+            if (ImGui::IsItemActive()) {
+                const ImVec2 d = ImGui::GetIO().MouseDelta;
+                st.simX += d.x / previewW;
+                st.simY += d.y / previewH;
+            }
+            ImGui::SetCursorScreenPos(ImVec2(bMax.x - 14.f, bMax.y - 14.f));
+            ImGui::InvisibleButton("##simResize", ImVec2(16.f, 16.f));
+            if (ImGui::IsItemActive()) {
+                const ImVec2 d = ImGui::GetIO().MouseDelta;
+                st.simW += d.x / previewW;
+                st.simH += d.y / previewH;
+            }
+
+            st.simW = Util::Clamp(st.simW, 0.05f, 1.f);
+            st.simH = Util::Clamp(st.simH, 0.05f, 1.f);
+            st.simX = Util::Clamp(st.simX, 0.f, 1.f - st.simW);
+            st.simY = Util::Clamp(st.simY, 0.f, 1.f - st.simH);
+
+            ImGui::SetCursorScreenPos(ImVec2(origin.x, origin.y + previewH + 4.f));
+        } else {
+            ImGui::TextDisabled("Load a video to position the overlay.");
+        }
+        if (app->LoadedFunscripts().empty())
+            ImGui::TextDisabled("No script loaded \xE2\x80\x94 nothing to composite.");
+    }
+
+    ImGui::Separator();
+    const char* videoPath = app->player->VideoPath();
+    const bool canExport = !exporting.load() && haveRange && rEnd > rStart && videoPath && *videoPath;
+
+    ImGui::BeginDisabled(!canExport);
+    if (ImGui::Button("Export\xE2\x80\xA6")) {
+        const char* filter = st.format == 0 ? "*.webp" : "*.webm";
+        const char* ext = st.format == 0 ? ".webp" : ".webm";
+        std::string defaultName = std::string("preview") + ext;
+        Util::SaveFileDialog("Export animated preview", defaultName,
+            [this, rStart, rEnd](Util::FileDialogResult& result) {
+                if (!result.files.empty()) beginExport(result.files[0], rStart, rEnd);
+            },
+            { filter });
+    }
+    ImGui::EndDisabled();
+
+    ImGui::SameLine();
+    if (exporting.load()) {
+        ImGui::TextDisabled("Exporting\xE2\x80\xA6");
+    } else if (hasRun) {
+        if (lastResult.load() == 0)
+            ImGui::TextColored(ImVec4(0.4f, 1.f, 0.4f, 1.f), "Done");
+        else
+            ImGui::TextColored(ImVec4(1.f, 0.4f, 0.4f, 1.f), "ffmpeg failed (%d)", lastResult.load());
+    }
+
+    if (st.format == 1)
+        ImGui::TextDisabled("AV1 requires an ffmpeg build with libsvtav1.");
+
+    ImGui::End();
+}

--- a/src/UI/OFS_PreviewExporter.cpp
+++ b/src/UI/OFS_PreviewExporter.cpp
@@ -4,12 +4,16 @@
 
 #include "OpenFunscripter.h"
 #include "OFS_Simulator3D.h"
+#include "Funscript.h"
 #include "OFS_Util.h"
 
 #include "subprocess.h"
 #include "imgui.h"
+#include "imgui_stdlib.h"
+#include "state/SimulatorState.h"
 #include "stb_sprintf.h"
 #include "stb_image_write.h"
+#include "OFS_FileLogging.h"
 
 #include <cmath>
 #include <cstdint>
@@ -17,118 +21,288 @@
 #include <thread>
 #include <vector>
 
+// Even output width for a target height at the video's aspect (16:9 fallback).
+static int widthForHeight(int h, uint16_t vw, uint16_t vh) noexcept
+{
+    int w = (vh > 0) ? (int)std::lround((double)vw * h / (double)vh) : (h * 16 / 9);
+    w -= (w & 1);
+    return w < 2 ? 2 : w;
+}
+
+// Stroke position (0..1) of the active script at time t; centered if it has no data.
+static float strokeAt(OpenFunscripter* app, float t) noexcept
+{
+    auto& s = app->ActiveFunscript();
+    if (!s || s->Actions().empty()) return 0.5f;
+    return s->GetPositionAtTime(t) / 100.f;
+}
+
+// The 2D ScriptSimulator's persisted config (colors/opacity), shared by the app.
+static SimulatorState& sim2DConfig() noexcept
+{
+    static const uint32_t handle = OFS_ProjectState<SimulatorState>::Register(SimulatorState::StateName);
+    return SimulatorState::State(handle);
+}
+
+// Pack an ImColor to ImU32 with the sim's global opacity folded into alpha.
+static ImU32 simColor(const ImColor& col, float opacity) noexcept
+{
+    ImVec4 v = col.Value;
+    v.w *= opacity;
+    return ImGui::ColorConvertFloat4ToU32(v);
+}
+
+// Previous/next scripted action positions (0..100, -1 if none) around time t.
+static void adjacentPos(std::shared_ptr<Funscript>& s, float t, int& prevPos, int& nextPos) noexcept
+{
+    prevPos = -1; nextPos = -1;
+    if (!s) return;
+    const FunscriptAction* pa = s->GetActionAtTime(t, 0.02f);
+    if (!pa) pa = s->GetPreviousActionBehind(t);
+    const FunscriptAction* na = s->GetNextActionAhead(t);
+    if (pa && na == pa) na = s->GetNextActionAhead(pa->atS);
+    if (pa) prevPos = pa->pos;
+    if (na) nextPos = na->pos;
+}
+
+// CPU-rasterize the 2D stroke bar into a top-down, transparent RGBA buffer, using
+// the ScriptSimulator's configured colors + height lines + indicators.
+static void renderBar2D(float pos01, int prevPos, int nextPos, int w, int h,
+                        const SimulatorState& sc, std::vector<uint8_t>& out) noexcept
+{
+    out.assign((size_t)w * (size_t)h * 4u, 0);
+    auto fill = [&](int x0, int y0, int x1, int y1, ImU32 c) {
+        if (x0 < 0) x0 = 0; if (y0 < 0) y0 = 0;
+        if (x1 > w) x1 = w; if (y1 > h) y1 = h;
+        const uint8_t r = c & 0xFF, g = (c >> 8) & 0xFF, b = (c >> 16) & 0xFF, a = (c >> 24) & 0xFF;
+        for (int y = y0; y < y1; ++y)
+            for (int x = x0; x < x1; ++x) {
+                const size_t i = ((size_t)y * w + x) * 4u;
+                out[i] = r; out[i + 1] = g; out[i + 2] = b; out[i + 3] = a;
+            }
+    };
+    const int barW = (int)(w * 0.42f);
+    const int bx0 = (w - barW) / 2, bx1 = bx0 + barW;
+    const int m = (int)(h * 0.04f);
+    const int by0 = m, by1 = h - m, barH = by1 - by0;
+    if (barW <= 0 || barH <= 0) return;
+    const float op = sc.GlobalOpacity;
+    auto hline = [&](float posPct, ImU32 c, int lw) {
+        if (lw < 1) lw = 1;
+        const int y = by1 - (int)((posPct / 100.f) * barH);
+        fill(bx0, y - lw / 2, bx1, y - lw / 2 + lw, c);
+    };
+    fill(bx0, by0, bx1, by1, simColor(sc.Back, op));                        // track
+    fill(bx0, by1 - (int)(pos01 * barH), bx1, by1, simColor(sc.Front, op)); // fill
+    if (sc.EnableHeightLines) {
+        const ImU32 lc = simColor(sc.ExtraLines, op);
+        for (int i = 1; i < 10; ++i) hline(i * 10.f, lc, (int)sc.LineWidth);
+    }
+    if (sc.EnableIndicators) {
+        const ImU32 ic = simColor(sc.Indicator, op);
+        if (prevPos > 0 && prevPos < 100) hline((float)prevPos, ic, (int)sc.LineWidth);
+        if (nextPos > 0 && nextPos < 100) hline((float)nextPos, ic, (int)sc.LineWidth);
+    }
+    const int bt = 2;                                                       // border
+    const ImU32 bc = simColor(sc.Border, op);
+    fill(bx0, by0, bx1, by0 + bt, bc);
+    fill(bx0, by1 - bt, bx1, by1, bc);
+    fill(bx0, by0, bx0 + bt, by1, bc);
+    fill(bx1 - bt, by0, bx1, by1, bc);
+}
+
 void OFS_PreviewExporter::Init() noexcept
 {
     stateHandle = OFS_AppState<PreviewExportState>::Register(PreviewExportState::StateName);
 }
 
-void OFS_PreviewExporter::beginExport(const std::string& outputPath, float start, float end) noexcept
+void OFS_PreviewExporter::spawnFfmpeg(std::vector<std::string> args, std::string tempDir) noexcept
 {
-    if (exporting.load()) return;
-    auto& st = PreviewExportState::State(stateHandle);
-    auto app = OpenFunscripter::ptr;
-    const char* videoPath = app->player->VideoPath();
-    if (!videoPath || !*videoPath || end <= start) return;
-
-    // Output dimensions: height fixed, width from the video aspect (even).
-    const int outH = st.resolution;
-    const uint16_t vw = app->player->VideoWidth();
-    const uint16_t vh = app->player->VideoHeight();
-    int outW = (vh > 0) ? (int)std::lround((double)vw * outH / (double)vh) : (outH * 16 / 9);
-    outW -= (outW & 1);
-    if (outW < 2) outW = 2;
-
-    // Optionally render the simulator to a transparent PNG sequence (main thread, GL).
-    const bool doOverlay = st.overlaySim && !app->LoadedFunscripts().empty();
-    std::string framePattern, tempDir;
-    int ox = 0, oy = 0;
-    if (doOverlay) {
-        int ow = ((int)std::lround(st.simW * outW)) & ~1; if (ow < 2) ow = 2;
-        int oh = ((int)std::lround(st.simH * outH)) & ~1; if (oh < 2) oh = 2;
-        ox = (int)std::lround(st.simX * outW);
-        oy = (int)std::lround(st.simY * outH);
-
-        tempDir = Util::Prefpath("preview_frames");
-        std::error_code ec;
-        std::filesystem::remove_all(std::filesystem::u8path(tempDir), ec);
-        Util::CreateDirectories(std::filesystem::u8path(tempDir));
-
-        int frames = (int)std::lround((double)(end - start) * st.fps);
-        if (frames < 1) frames = 1;
-
-        auto& sim = app->GetSimulator3D();
-        auto& scripts = app->LoadedFunscripts();
-        std::vector<uint8_t> pixels;
-        for (int i = 0; i < frames; ++i) {
-            const float t = start + (float)i / (float)st.fps;
-            if (!sim.RenderPoseRGBA(scripts, t, ow, oh, pixels)) break;
-            char name[32];
-            stbsp_snprintf(name, sizeof(name), "frame_%05d.png", i);
-            const auto p = (std::filesystem::u8path(tempDir) / name).u8string();
-            stbi_write_png(p.c_str(), ow, oh, 4, pixels.data(), ow * 4);
-        }
-        framePattern = (std::filesystem::u8path(tempDir) / "frame_%05d.png").u8string();
+    { // log the exact command so failures are diagnosable from the log file
+        std::string cmd;
+        for (auto& s : args) { cmd += '"'; cmd += s; cmd += "\" "; }
+        LOGF_INFO("[PreviewExport] %s", cmd.c_str());
     }
-
-    const std::string ffmpeg = Util::FfmpegPath().u8string();
-    char buf[160];
-
-    std::vector<std::string> a;
-    a.push_back(ffmpeg);
-    a.push_back("-y");
-    a.push_back("-hide_banner");
-    a.push_back("-loglevel"); a.push_back("error"); // keep stderr small
-    stbsp_snprintf(buf, sizeof(buf), "%.3f", start);       a.push_back("-ss"); a.push_back(buf);
-    a.push_back("-i"); a.push_back(videoPath);
-    stbsp_snprintf(buf, sizeof(buf), "%.3f", end - start); a.push_back("-t"); a.push_back(buf);
-
-    if (doOverlay) {
-        stbsp_snprintf(buf, sizeof(buf), "%d", st.fps); a.push_back("-framerate"); a.push_back(buf);
-        a.push_back("-i"); a.push_back(framePattern);
-        stbsp_snprintf(buf, sizeof(buf), "[0:v]fps=%d,scale=-2:%d[bg];[bg][1:v]overlay=%d:%d",
-                       st.fps, st.resolution, ox, oy);
-        a.push_back("-filter_complex"); a.push_back(buf);
-    } else {
-        stbsp_snprintf(buf, sizeof(buf), "fps=%d,scale=-2:%d:flags=lanczos", st.fps, st.resolution);
-        a.push_back("-vf"); a.push_back(buf);
-    }
-    a.push_back("-an");
-
-    if (st.format == 0) { // animated WebP
-        a.push_back("-c:v"); a.push_back("libwebp");
-        stbsp_snprintf(buf, sizeof(buf), "%d", st.quality); a.push_back("-q:v"); a.push_back(buf);
-        a.push_back("-loop"); a.push_back("0");
-    } else { // AV1 (webm)
-        const int crf = (int)std::lround((100.0 - st.quality) * 0.63); // quality 100->crf 0, 0->63
-        a.push_back("-c:v"); a.push_back("libsvtav1");
-        stbsp_snprintf(buf, sizeof(buf), "%d", crf); a.push_back("-crf"); a.push_back(buf);
-        a.push_back("-b:v"); a.push_back("0");
-    }
-    a.push_back(outputPath);
-
+    lastErrorText.clear();
     exporting.store(true);
     hasRun = true;
-    std::thread([this, a = std::move(a), tempDir]() mutable {
+    std::thread([this, args = std::move(args), tempDir = std::move(tempDir)]() mutable {
         std::vector<const char*> argv;
-        argv.reserve(a.size() + 1);
-        for (auto& s : a) argv.push_back(s.c_str());
+        argv.reserve(args.size() + 1);
+        for (auto& s : args) argv.push_back(s.c_str());
         argv.push_back(nullptr);
 
         int rc = -1;
+        std::string err;
         struct subprocess_s proc;
         if (subprocess_create(argv.data(), subprocess_option_no_window, &proc) == 0) {
             if (proc.stdout_file) { fclose(proc.stdout_file); proc.stdout_file = nullptr; }
-            if (proc.stderr_file) { fclose(proc.stderr_file); proc.stderr_file = nullptr; }
             subprocess_join(&proc, &rc);
+            // Read ffmpeg's stderr (kept small by -loglevel error) for diagnostics.
+            if (proc.stderr_file) {
+                char b[512];
+                size_t n;
+                while ((n = fread(b, 1, sizeof(b), proc.stderr_file)) > 0)
+                    err.append(b, n);
+            }
             subprocess_destroy(&proc);
         }
         if (!tempDir.empty()) {
             std::error_code ec;
             std::filesystem::remove_all(std::filesystem::u8path(tempDir), ec);
         }
+        lastErrorText = std::move(err);
         lastResult.store(rc);
+        if (rc != 0) LOGF_ERROR("[PreviewExport] ffmpeg failed (%d): %s", rc, lastErrorText.c_str());
         exporting.store(false);
     }).detach();
+}
+
+void OFS_PreviewExporter::OpenForChapter(float start, float end) noexcept
+{
+    auto& st = PreviewExportState::State(stateHandle);
+    st.rangeMode = 1; // timestamps
+    startTime = start;
+    endTime = end;
+    startEditing = false;
+    endEditing = false;
+}
+
+void OFS_PreviewExporter::startExport(const std::string& outputPath, float start, float end) noexcept
+{
+    if (exporting.load() || renderingFrames) return;
+    auto& st = PreviewExportState::State(stateHandle);
+    auto app = OpenFunscripter::ptr;
+    const char* videoPath = app->player->VideoPath();
+    if (!videoPath || !*videoPath || end <= start) return;
+
+    const int outH = st.resolution;
+    const uint16_t vw = app->player->VideoWidth();
+    const uint16_t vh = app->player->VideoHeight();
+    const int outW = widthForHeight(outH, vw, vh);
+
+    const bool doOverlay = st.overlaySim && !app->LoadedFunscripts().empty();
+
+    char buf[192];
+    std::string tempDir, framePattern;
+    int ox = 0, oy = 0, ow = 0, oh = 0;
+    if (doOverlay) {
+        ow = ((int)std::lround(st.simW * outW)) & ~1; if (ow < 2) ow = 2;
+        oh = ((int)std::lround(st.simH * outH)) & ~1; if (oh < 2) oh = 2;
+        ox = (int)std::lround(st.simX * outW);
+        oy = (int)std::lround(st.simY * outH);
+        tempDir = Util::Prefpath("preview_frames");
+        std::error_code ec;
+        std::filesystem::remove_all(std::filesystem::u8path(tempDir), ec);
+        Util::CreateDirectories(std::filesystem::u8path(tempDir));
+        framePattern = (std::filesystem::u8path(tempDir) / "frame_%05d.png").u8string();
+    }
+
+    // Use OFS's ffmpeg (now the gyan "full" build, which includes libsvtav1).
+    const std::string ffmpeg = Util::FfmpegPath().u8string();
+    std::vector<std::string> a;
+    a.push_back(ffmpeg);
+    a.push_back("-y");
+    a.push_back("-hide_banner");
+    a.push_back("-loglevel"); a.push_back("error");
+    // -ss and -t must both be INPUT options on the video (before -i). In overlay
+    // mode a second -i follows, so a -t placed after -i video would bind to that
+    // input instead of trimming the video -> the whole clip would export.
+    stbsp_snprintf(buf, sizeof(buf), "%.3f", start);       a.push_back("-ss"); a.push_back(buf);
+    stbsp_snprintf(buf, sizeof(buf), "%.3f", end - start); a.push_back("-t"); a.push_back(buf);
+    a.push_back("-i"); a.push_back(videoPath);
+
+    if (doOverlay) {
+        stbsp_snprintf(buf, sizeof(buf), "%d", st.fps); a.push_back("-framerate"); a.push_back(buf);
+        a.push_back("-i"); a.push_back(framePattern);
+        stbsp_snprintf(buf, sizeof(buf), "[0:v]fps=%d,scale=%d:%d[bg];[bg][1:v]overlay=%d:%d[outv]",
+                       st.fps, outW, outH, ox, oy);
+        a.push_back("-filter_complex"); a.push_back(buf);
+        // filter_complex disables auto stream selection, so map explicitly.
+        a.push_back("-map"); a.push_back("[outv]");
+        if (st.format == 1) { a.push_back("-map"); a.push_back("0:a?"); } // source audio for AV1
+    } else {
+        stbsp_snprintf(buf, sizeof(buf), "fps=%d", st.fps);
+        a.push_back("-filter:v"); a.push_back(buf);
+        stbsp_snprintf(buf, sizeof(buf), "%dx%d", outW, outH);
+        a.push_back("-s"); a.push_back(buf);
+    }
+
+    if (st.format == 0) { // animated WebP (lossless)
+        a.push_back("-vcodec"); a.push_back("libwebp");
+        a.push_back("-lossless"); a.push_back("1");
+        a.push_back("-loop"); a.push_back("0");
+        a.push_back("-preset"); a.push_back("default");
+    } else { // AV1 (mp4) via libsvtav1 (from PATH ffmpeg)
+        const int preset = Util::Clamp(st.av1Preset, 0, 13);
+        a.push_back("-c:v"); a.push_back("libsvtav1");
+        a.push_back("-crf"); a.push_back("30");
+        a.push_back("-b:v"); a.push_back("0");
+        stbsp_snprintf(buf, sizeof(buf), "%d", preset);
+        a.push_back("-preset"); a.push_back(buf);
+    }
+    if (st.format == 1) { // AV1/mp4 carries the source audio; WebP cannot
+        a.push_back("-c:a"); a.push_back("aac");
+        a.push_back("-b:a"); a.push_back("192k");
+    } else {
+        a.push_back("-an");
+    }
+    a.push_back(outputPath);
+
+    if (doOverlay) {
+        // Kick off the incremental frame-render job; ffmpeg spawns when it finishes.
+        int frames = (int)std::lround((double)(end - start) * st.fps);
+        if (frames < 1) frames = 1;
+        jobFrame = 0;
+        jobFrameCount = frames;
+        jobW = ow; jobH = oh;
+        jobStart = start;
+        jobFps = (float)st.fps;
+        jobTempDir = tempDir;
+        jobArgs = std::move(a);
+        renderingFrames = true;
+        exporting.store(true); // UI shows busy through the whole job
+        hasRun = true;
+    } else {
+        spawnFfmpeg(std::move(a), std::string());
+    }
+}
+
+void OFS_PreviewExporter::Update() noexcept
+{
+    if (!renderingFrames) return;
+    auto app = OpenFunscripter::ptr;
+    auto& sim = app->GetSimulator3D();
+    auto& scripts = app->LoadedFunscripts();
+    const bool use2D = PreviewExportState::State(stateHandle).sim2D;
+    const SimulatorState* sc2D = use2D ? &sim2DConfig() : nullptr;
+
+    // Render a small batch per UI frame to keep the app responsive.
+    constexpr int kBatch = 4;
+    for (int k = 0; k < kBatch && jobFrame < jobFrameCount; ++k, ++jobFrame) {
+        const float t = jobStart + (float)jobFrame / jobFps;
+        bool ok = true;
+        if (use2D) {
+            int pp, np;
+            adjacentPos(app->ActiveFunscript(), t, pp, np);
+            renderBar2D(strokeAt(app, t), pp, np, jobW, jobH, *sc2D, jobPixels);
+        } else {
+            ok = sim.RenderPoseRGBA(scripts, t, jobW, jobH, jobPixels);
+        }
+        if (ok) {
+            char name[32];
+            stbsp_snprintf(name, sizeof(name), "frame_%05d.png", jobFrame);
+            const auto p = (std::filesystem::u8path(jobTempDir) / name).u8string();
+            stbi_write_png(p.c_str(), jobW, jobH, 4, jobPixels.data(), jobW * 4);
+        }
+    }
+
+    if (jobFrame >= jobFrameCount) {
+        renderingFrames = false;
+        spawnFfmpeg(std::move(jobArgs), std::move(jobTempDir));
+        jobArgs.clear();
+        jobTempDir.clear();
+    }
 }
 
 void OFS_PreviewExporter::ShowWindow(bool* open) noexcept
@@ -136,57 +310,72 @@ void OFS_PreviewExporter::ShowWindow(bool* open) noexcept
     if (!*open) return;
     auto& st = PreviewExportState::State(stateHandle);
     auto app = OpenFunscripter::ptr;
+    const uint16_t vw = app->player->VideoWidth();
+    const uint16_t vh = app->player->VideoHeight();
 
     ImGui::Begin("Animated Preview Export###PREVIEW_EXPORT", open, ImGuiWindowFlags_None);
 
-    ImGui::Combo("Format", &st.format, "Animated WebP\0AV1 (webm)\0\0");
-    if (ImGui::InputInt("Height (px)", &st.resolution)) st.resolution = Util::Clamp(st.resolution, 64, 2160);
+    ImGui::Combo("Format", &st.format, "Animated WebP\0AV1 (mp4)\0\0");
+
+    // Resolution: standard heights <= native, at the video's aspect.
+    {
+        char curLabel[32];
+        stbsp_snprintf(curLabel, sizeof(curLabel), "%dx%d", widthForHeight(st.resolution, vw, vh), st.resolution);
+        if (ImGui::BeginCombo("Resolution", curLabel)) {
+            static const int heights[] = {2160, 1440, 1080, 720, 540, 480, 360, 240};
+            for (int h : heights) {
+                if (vh > 0 && h > (int)vh) continue; // no upscaling
+                char lbl[32];
+                stbsp_snprintf(lbl, sizeof(lbl), "%dx%d", widthForHeight(h, vw, vh), h);
+                if (ImGui::Selectable(lbl, st.resolution == h)) st.resolution = h;
+            }
+            ImGui::EndCombo();
+        }
+    }
+
     if (ImGui::InputInt("FPS", &st.fps)) st.fps = Util::Clamp(st.fps, 1, 60);
-    ImGui::SliderInt("Quality", &st.quality, 0, 100);
+
+    if (st.format == 0) {
+        ImGui::TextDisabled("WebP is exported lossless.");
+    } else {
+        if (ImGui::SliderInt("AV1 speed/preset", &st.av1Preset, 0, 13))
+            st.av1Preset = Util::Clamp(st.av1Preset, 0, 13);
+        ImGui::SameLine();
+        ImGui::TextDisabled("(0 best \xE2\x80\xA2 13 fast)");
+    }
 
     ImGui::Separator();
-    ImGui::RadioButton("Chapter", &st.rangeMode, 0);
-    ImGui::SameLine();
-    ImGui::RadioButton("Timestamps", &st.rangeMode, 1);
+    ImGui::TextDisabled("Range (use the chapter right-click menu to fill this from a chapter)");
 
     const double duration = app->player->Duration();
-    float rStart = 0.f, rEnd = 0.f;
-    bool haveRange = false;
-
-    if (st.rangeMode == 0) {
-        auto& chapters = ChapterState::StaticStateSlow().chapters;
-        if (chapters.empty()) {
-            ImGui::TextDisabled("No chapters \xE2\x80\x94 add chapters or switch to Timestamps.");
-        } else {
-            selectedChapter = Util::Clamp(selectedChapter, 0, (int)chapters.size() - 1);
-            if (ImGui::BeginCombo("Chapter", chapters[selectedChapter].name.c_str())) {
-                for (int i = 0; i < (int)chapters.size(); ++i) {
-                    if (ImGui::Selectable(chapters[i].name.c_str(), i == selectedChapter))
-                        selectedChapter = i;
-                }
-                ImGui::EndCombo();
-            }
-            rStart = chapters[selectedChapter].startTime;
-            rEnd = chapters[selectedChapter].endTime;
-            haveRange = true;
+    // HH:MM:SS.mmm text fields, matching the timeline format.
+    auto timeField = [&](const char* label, float& seconds, std::string& str, bool& editing) {
+        if (!editing) {
+            char b[32];
+            Util::FormatTime(b, sizeof(b), seconds, true);
+            str = b;
         }
-    } else {
-        ImGui::InputFloat("Start (s)", &startTime);
-        ImGui::InputFloat("End (s)", &endTime);
-        startTime = Util::Clamp(startTime, 0.f, (float)duration);
-        endTime = Util::Clamp(endTime, 0.f, (float)duration);
-        rStart = startTime;
-        rEnd = endTime;
-        haveRange = true;
-    }
+        ImGui::InputText(label, &str);
+        editing = ImGui::IsItemActive();
+        if (ImGui::IsItemDeactivatedAfterEdit()) {
+            bool ok = false;
+            const float v = Util::ParseTime(str.c_str(), &ok);
+            if (ok) seconds = Util::Clamp(v, 0.f, (float)duration);
+        }
+    };
+    timeField("Start (h:m:s.ms)", startTime, startStr, startEditing);
+    timeField("End (h:m:s.ms)", endTime, endStr, endEditing);
+    const float rStart = startTime;
+    const float rEnd = endTime;
+    const bool haveRange = true;
 
     // ---- Overlay the simulator on the video (draggable live preview) ----
     ImGui::Separator();
     ImGui::Checkbox("Overlay simulator on video", &st.overlaySim);
     if (st.overlaySim) {
+        ImGui::SameLine();
+        ImGui::Checkbox("2D bar (single axis)", &st.sim2D);
         const uint32_t frameTex = app->player->FrameTexture();
-        const uint16_t vw = app->player->VideoWidth();
-        const uint16_t vh = app->player->VideoHeight();
         if (frameTex && vw > 0 && vh > 0) {
             ImGui::TextDisabled("Drag to move \xE2\x80\xA2 drag corner to resize");
             float previewW = ImGui::GetContentRegionAvail().x;
@@ -201,31 +390,71 @@ void OFS_PreviewExporter::ShowWindow(bool* open) noexcept
             const int bh = (int)(st.simH * previewH);
             const ImVec2 bMax(bMin.x + bw, bMin.y + bh);
 
-            // Live sim rendered into the box at the current playhead time.
             if (bw > 4 && bh > 4 && !app->LoadedFunscripts().empty()) {
-                const uint32_t simTex = app->GetSimulator3D().RenderPoseTexture(
-                    app->LoadedFunscripts(), (float)app->player->CurrentTime(), bw, bh);
-                dl->AddImage((ImTextureID)(intptr_t)simTex, bMin, bMax, ImVec2(0, 1), ImVec2(1, 0));
+                if (st.sim2D) {
+                    // 2D stroke bar matching the ScriptSimulator (colors + height lines + indicators).
+                    auto& sc = sim2DConfig();
+                    const float op = sc.GlobalOpacity;
+                    const float ct = (float)app->player->CurrentTime();
+                    const float pos01 = strokeAt(app, ct);
+                    const float trackW = (bMax.x - bMin.x) * 0.42f;
+                    const float tx0 = bMin.x + ((bMax.x - bMin.x) - trackW) * 0.5f, tx1 = tx0 + trackW;
+                    const float mrg = (bMax.y - bMin.y) * 0.04f;
+                    const float ty0 = bMin.y + mrg, ty1 = bMax.y - mrg, barH = ty1 - ty0;
+                    dl->AddRectFilled(ImVec2(tx0, ty0), ImVec2(tx1, ty1), simColor(sc.Back, op));
+                    dl->AddRectFilled(ImVec2(tx0, ty1 - pos01 * barH), ImVec2(tx1, ty1), simColor(sc.Front, op));
+                    if (sc.EnableHeightLines) {
+                        const ImU32 lc = simColor(sc.ExtraLines, op);
+                        for (int i = 1; i < 10; ++i) {
+                            const float y = ty1 - (i * 0.1f) * barH;
+                            dl->AddLine(ImVec2(tx0, y), ImVec2(tx1, y), lc, sc.LineWidth);
+                        }
+                    }
+                    if (sc.EnableIndicators) {
+                        int pp, np;
+                        adjacentPos(app->ActiveFunscript(), ct, pp, np);
+                        const ImU32 ic = simColor(sc.Indicator, op);
+                        const ImU32 tc = simColor(sc.Text, op);
+                        auto ind = [&](int pos) {
+                            if (pos <= 0 || pos >= 100) return;
+                            const float y = ty1 - (pos * 0.01f) * barH;
+                            dl->AddLine(ImVec2(tx0, y), ImVec2(tx1, y), ic, sc.LineWidth);
+                            char b[8]; stbsp_snprintf(b, sizeof(b), "%d", pos);
+                            dl->AddText(ImVec2((tx0 + tx1) * 0.5f - 7.f, y - 7.f), tc, b);
+                        };
+                        ind(pp); ind(np);
+                    }
+                    dl->AddRect(ImVec2(tx0, ty0), ImVec2(tx1, ty1), simColor(sc.Border, op), 0.f, 0, 2.f);
+                } else {
+                    const uint32_t simTex = app->GetSimulator3D().RenderPoseTexture(
+                        app->LoadedFunscripts(), (float)app->player->CurrentTime(), bw, bh);
+                    dl->AddImage((ImTextureID)(intptr_t)simTex, bMin, bMax, ImVec2(0, 1), ImVec2(1, 0));
+                }
             }
+            const float grip = 22.f; // easy-to-grab resize corner
             dl->AddRect(bMin, bMax, IM_COL32(0xFF, 0xE0, 0x40, 0xD0), 0.f, 0, 2.f);
-            dl->AddTriangleFilled(ImVec2(bMax.x - 12, bMax.y), bMax, ImVec2(bMax.x, bMax.y - 12),
+            dl->AddTriangleFilled(ImVec2(bMax.x - grip, bMax.y), bMax, ImVec2(bMax.x, bMax.y - grip),
                                   IM_COL32(0xFF, 0xE0, 0x40, 0xF0));
 
-            // Move handle (whole box) + resize handle (corner).
+            // One handle over the whole box; the drag's starting position (corner or
+            // not) decides resize vs move. Avoids unreliable overlapping-button clicks.
             ImGui::SetCursorScreenPos(bMin);
-            ImGui::InvisibleButton("##simMove", ImVec2((float)bw, (float)bh));
-            ImGui::SetItemAllowOverlap();
+            ImGui::InvisibleButton("##simBox", ImVec2((float)bw, (float)bh));
+            const ImVec2 mp = ImGui::GetIO().MousePos;
+            const bool inCorner = (mp.x >= bMax.x - grip && mp.y >= bMax.y - grip);
+            if (ImGui::IsItemActivated())
+                draggingResize = inCorner;
+            if ((ImGui::IsItemHovered() && inCorner) || (draggingResize && ImGui::IsItemActive()))
+                ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeNWSE);
             if (ImGui::IsItemActive()) {
                 const ImVec2 d = ImGui::GetIO().MouseDelta;
-                st.simX += d.x / previewW;
-                st.simY += d.y / previewH;
-            }
-            ImGui::SetCursorScreenPos(ImVec2(bMax.x - 14.f, bMax.y - 14.f));
-            ImGui::InvisibleButton("##simResize", ImVec2(16.f, 16.f));
-            if (ImGui::IsItemActive()) {
-                const ImVec2 d = ImGui::GetIO().MouseDelta;
-                st.simW += d.x / previewW;
-                st.simH += d.y / previewH;
+                if (draggingResize) {
+                    st.simW += d.x / previewW;
+                    st.simH += d.y / previewH;
+                } else {
+                    st.simX += d.x / previewW;
+                    st.simY += d.y / previewH;
+                }
             }
 
             st.simW = Util::Clamp(st.simW, 0.05f, 1.f);
@@ -243,24 +472,27 @@ void OFS_PreviewExporter::ShowWindow(bool* open) noexcept
 
     ImGui::Separator();
     const char* videoPath = app->player->VideoPath();
-    const bool canExport = !exporting.load() && haveRange && rEnd > rStart && videoPath && *videoPath;
+    const bool busy = exporting.load() || renderingFrames;
+    const bool canExport = !busy && haveRange && rEnd > rStart && videoPath && *videoPath;
 
     ImGui::BeginDisabled(!canExport);
     if (ImGui::Button("Export\xE2\x80\xA6")) {
-        const char* filter = st.format == 0 ? "*.webp" : "*.webm";
-        const char* ext = st.format == 0 ? ".webp" : ".webm";
+        const char* filter = st.format == 0 ? "*.webp" : "*.mp4";
+        const char* ext = st.format == 0 ? ".webp" : ".mp4";
         std::string defaultName = std::string("preview") + ext;
         Util::SaveFileDialog("Export animated preview", defaultName,
             [this, rStart, rEnd](Util::FileDialogResult& result) {
-                if (!result.files.empty()) beginExport(result.files[0], rStart, rEnd);
+                if (!result.files.empty()) startExport(result.files[0], rStart, rEnd);
             },
             { filter });
     }
     ImGui::EndDisabled();
 
     ImGui::SameLine();
-    if (exporting.load()) {
-        ImGui::TextDisabled("Exporting\xE2\x80\xA6");
+    if (renderingFrames) {
+        ImGui::TextDisabled("Rendering frames %d/%d\xE2\x80\xA6", jobFrame, jobFrameCount);
+    } else if (exporting.load()) {
+        ImGui::TextDisabled("Encoding\xE2\x80\xA6");
     } else if (hasRun) {
         if (lastResult.load() == 0)
             ImGui::TextColored(ImVec4(0.4f, 1.f, 0.4f, 1.f), "Done");
@@ -268,8 +500,14 @@ void OFS_PreviewExporter::ShowWindow(bool* open) noexcept
             ImGui::TextColored(ImVec4(1.f, 0.4f, 0.4f, 1.f), "ffmpeg failed (%d)", lastResult.load());
     }
 
+    if (hasRun && !exporting.load() && !renderingFrames && lastResult.load() != 0 && !lastErrorText.empty()) {
+        ImGui::PushTextWrapPos(0.f);
+        ImGui::TextColored(ImVec4(1.f, 0.6f, 0.6f, 1.f), "%s", lastErrorText.c_str());
+        ImGui::PopTextWrapPos();
+    }
+
     if (st.format == 1)
-        ImGui::TextDisabled("AV1 requires an ffmpeg build with libsvtav1.");
+        ImGui::TextDisabled("AV1 uses libsvtav1.");
 
     ImGui::End();
 }

--- a/src/UI/OFS_PreviewExporter.cpp
+++ b/src/UI/OFS_PreviewExporter.cpp
@@ -372,7 +372,7 @@ void OFS_PreviewExporter::Update() noexcept
             case LayerKind::Timeline:
                 ok = OFS_TimelineRaster::Render(scripts, activeIdx, t, st.timelineVisibleTime,
                                                 L.w, L.h, st.timelineShowHeightLines,
-                                                st.timelineAllScripts, L.pixels);
+                                                st.timelineShowLabels, st.timelineAllScripts, L.pixels);
                 break;
             }
             if (ok && st.simShowHeightText && (L.kind == LayerKind::Sim2D || L.kind == LayerKind::Sim3D)) {
@@ -416,7 +416,8 @@ void OFS_PreviewExporter::ShowWindow(bool* open) noexcept
         char curLabel[32];
         stbsp_snprintf(curLabel, sizeof(curLabel), "%dx%d", widthForHeight(st.resolution, vw, vh), st.resolution);
         if (ImGui::BeginCombo("Resolution", curLabel)) {
-            static const int heights[] = {2160, 1440, 1080, 720, 540, 480, 360, 240};
+            // 90 gives 160x90 for 16:9 sources (thumbnails); 180 -> 320x180.
+            static const int heights[] = {2160, 1440, 1080, 720, 540, 480, 360, 240, 180, 90};
             for (int h : heights) {
                 if (vh > 0 && h > (int)vh) continue; // no upscaling
                 char lbl[32];
@@ -607,6 +608,8 @@ void OFS_PreviewExporter::ShowWindow(bool* open) noexcept
         if (ImGui::SliderFloat("Strip height", &st.timelineHeightFrac, 0.05f, 0.6f, "%.2f"))
             st.timelineHeightFrac = Util::Clamp(st.timelineHeightFrac, 0.05f, 0.6f);
         ImGui::Checkbox("Height lines", &st.timelineShowHeightLines);
+        ImGui::SameLine();
+        ImGui::Checkbox("Axis names", &st.timelineShowLabels);
         ImGui::Checkbox("Include all enabled scripts (multi-axis)", &st.timelineAllScripts);
 
         if (app->LoadedFunscripts().empty()) {
@@ -619,7 +622,7 @@ void OFS_PreviewExporter::ShowWindow(bool* open) noexcept
             OFS_TimelineRaster::DrawInto(ImGui::GetWindowDrawList(), origin, ImVec2(previewW, stripH),
                               app->LoadedFunscripts(), (int)app->LoadedProject->ActiveIdx(),
                               (float)app->player->CurrentTime(), st.timelineVisibleTime,
-                              st.timelineShowHeightLines, st.timelineAllScripts);
+                              st.timelineShowHeightLines, st.timelineShowLabels, st.timelineAllScripts);
             ImGui::Dummy(ImVec2(previewW, stripH));
         }
     }

--- a/src/UI/OFS_PreviewExporter.cpp
+++ b/src/UI/OFS_PreviewExporter.cpp
@@ -4,6 +4,8 @@
 
 #include "OpenFunscripter.h"
 #include "OFS_Simulator3D.h"
+#include "OFS_TimelineRasterizer.h"
+#include "OFS_Project.h"
 #include "Funscript.h"
 #include "OFS_Util.h"
 
@@ -111,12 +113,33 @@ static void renderBar2D(float pos01, int prevPos, int nextPos, int w, int h,
     fill(bx1 - bt, by0, bx1, by1, bc);
 }
 
+// Alpha-composite a straight-alpha RGBA overlay (same size) over a destination
+// RGBA buffer, in place. Used to lay baked text onto a rendered sim frame.
+static void compositeOver(std::vector<uint8_t>& dst, const std::vector<uint8_t>& src, int w, int h) noexcept
+{
+    const size_t n = (size_t)w * (size_t)h;
+    if (dst.size() < n * 4 || src.size() < n * 4) return;
+    for (size_t i = 0; i < n; ++i) {
+        const size_t p = i * 4u;
+        const uint8_t sa = src[p + 3];
+        if (sa == 0) continue;
+        if (sa == 255) {
+            dst[p] = src[p]; dst[p + 1] = src[p + 1]; dst[p + 2] = src[p + 2]; dst[p + 3] = 255;
+            continue;
+        }
+        const float a = sa / 255.f, ia = 1.f - a;
+        for (int c = 0; c < 3; ++c)
+            dst[p + c] = (uint8_t)(src[p + c] * a + dst[p + c] * ia + 0.5f);
+        dst[p + 3] = (uint8_t)(sa + dst[p + 3] * ia + 0.5f);
+    }
+}
+
 void OFS_PreviewExporter::Init() noexcept
 {
     stateHandle = OFS_AppState<PreviewExportState>::Register(PreviewExportState::StateName);
 }
 
-void OFS_PreviewExporter::spawnFfmpeg(std::vector<std::string> args, std::string tempDir) noexcept
+void OFS_PreviewExporter::spawnFfmpeg(std::vector<std::string> args, std::vector<std::string> tempDirs) noexcept
 {
     { // log the exact command so failures are diagnosable from the log file
         std::string cmd;
@@ -126,7 +149,7 @@ void OFS_PreviewExporter::spawnFfmpeg(std::vector<std::string> args, std::string
     lastErrorText.clear();
     exporting.store(true);
     hasRun = true;
-    std::thread([this, args = std::move(args), tempDir = std::move(tempDir)]() mutable {
+    std::thread([this, args = std::move(args), tempDirs = std::move(tempDirs)]() mutable {
         std::vector<const char*> argv;
         argv.reserve(args.size() + 1);
         for (auto& s : args) argv.push_back(s.c_str());
@@ -147,9 +170,10 @@ void OFS_PreviewExporter::spawnFfmpeg(std::vector<std::string> args, std::string
             }
             subprocess_destroy(&proc);
         }
-        if (!tempDir.empty()) {
+        for (auto& d : tempDirs) {
+            if (d.empty()) continue;
             std::error_code ec;
-            std::filesystem::remove_all(std::filesystem::u8path(tempDir), ec);
+            std::filesystem::remove_all(std::filesystem::u8path(d), ec);
         }
         lastErrorText = std::move(err);
         lastResult.store(rc);
@@ -176,27 +200,50 @@ void OFS_PreviewExporter::startExport(const std::string& outputPath, float start
     const char* videoPath = app->player->VideoPath();
     if (!videoPath || !*videoPath || end <= start) return;
 
-    const int outH = st.resolution;
+    const int outH = st.resolution; // height of the video region
     const uint16_t vw = app->player->VideoWidth();
     const uint16_t vh = app->player->VideoHeight();
-    const int outW = widthForHeight(outH, vw, vh);
+    // With 16:9 padding the video region becomes a fixed landscape frame; the
+    // source is scaled to fit and centered inside it with black bars.
+    const int outW = st.padTo169 ? (((int)std::lround(outH * 16.0 / 9.0)) & ~1)
+                                 : widthForHeight(outH, vw, vh);
 
-    const bool doOverlay = st.overlaySim && !app->LoadedFunscripts().empty();
+    const bool haveScript = !app->LoadedFunscripts().empty();
+    const bool doSim = st.overlaySim && haveScript;
+    const bool doTimeline = st.overlayTimeline && haveScript;
+    const bool needFrames = doSim || doTimeline;
+    const bool useFC = needFrames || st.padTo169; // needs -filter_complex
 
-    char buf[192];
-    std::string tempDir, framePattern;
+    // Timeline strip band height (extends the canvas below the video region).
+    int bandH = 0;
+    if (doTimeline) { bandH = ((int)std::lround(st.timelineHeightFrac * outH)) & ~1; if (bandH < 2) bandH = 2; }
+    const int totalH = outH + bandH;
+
+    // Sim overlay rect, positioned against the (padded) video region.
     int ox = 0, oy = 0, ow = 0, oh = 0;
-    if (doOverlay) {
+    if (doSim) {
         ow = ((int)std::lround(st.simW * outW)) & ~1; if (ow < 2) ow = 2;
         oh = ((int)std::lround(st.simH * outH)) & ~1; if (oh < 2) oh = 2;
         ox = (int)std::lround(st.simX * outW);
         oy = (int)std::lround(st.simY * outH);
-        tempDir = Util::Prefpath("preview_frames");
-        std::error_code ec;
-        std::filesystem::remove_all(std::filesystem::u8path(tempDir), ec);
-        Util::CreateDirectories(std::filesystem::u8path(tempDir));
-        framePattern = (std::filesystem::u8path(tempDir) / "frame_%05d.png").u8string();
     }
+
+    // Set up one PNG-sequence layer per enabled overlay stream (sim first, then
+    // timeline) so the ffmpeg input indices below line up.
+    std::vector<ExportLayer> layers;
+    auto addLayer = [&](LayerKind kind, int w, int h, const char* dirName, const char* prefix) {
+        ExportLayer L;
+        L.kind = kind; L.w = w; L.h = h; L.filePrefix = prefix;
+        L.tempDir = Util::Prefpath(dirName);
+        std::error_code ec;
+        std::filesystem::remove_all(std::filesystem::u8path(L.tempDir), ec);
+        Util::CreateDirectories(std::filesystem::u8path(L.tempDir));
+        layers.push_back(std::move(L));
+    };
+    if (doSim) addLayer(st.sim2D ? LayerKind::Sim2D : LayerKind::Sim3D, ow, oh, "preview_frames", "frame_");
+    if (doTimeline) addLayer(LayerKind::Timeline, outW, bandH, "preview_tl", "tl_");
+
+    char buf[256];
 
     // Use OFS's ffmpeg (now the gyan "full" build, which includes libsvtav1).
     const std::string ffmpeg = Util::FfmpegPath().u8string();
@@ -205,21 +252,48 @@ void OFS_PreviewExporter::startExport(const std::string& outputPath, float start
     a.push_back("-y");
     a.push_back("-hide_banner");
     a.push_back("-loglevel"); a.push_back("error");
-    // -ss and -t must both be INPUT options on the video (before -i). In overlay
-    // mode a second -i follows, so a -t placed after -i video would bind to that
-    // input instead of trimming the video -> the whole clip would export.
+    // -ss and -t must both be INPUT options on the video (before -i). When extra
+    // overlay inputs follow, a -t placed after -i video would bind to those inputs
+    // instead of trimming the video -> the whole clip would export.
     stbsp_snprintf(buf, sizeof(buf), "%.3f", start);       a.push_back("-ss"); a.push_back(buf);
     stbsp_snprintf(buf, sizeof(buf), "%.3f", end - start); a.push_back("-t"); a.push_back(buf);
     a.push_back("-i"); a.push_back(videoPath);
 
-    if (doOverlay) {
-        stbsp_snprintf(buf, sizeof(buf), "%d", st.fps); a.push_back("-framerate"); a.push_back(buf);
-        a.push_back("-i"); a.push_back(framePattern);
-        stbsp_snprintf(buf, sizeof(buf), "[0:v]fps=%d,scale=%d:%d[bg];[bg][1:v]overlay=%d:%d[outv]",
-                       st.fps, outW, outH, ox, oy);
-        a.push_back("-filter_complex"); a.push_back(buf);
+    if (useFC) {
+        // Add a framerate-tagged image-sequence input for each overlay layer.
+        int simInput = -1, tlInput = -1, nextInput = 1;
+        for (auto& L : layers) {
+            stbsp_snprintf(buf, sizeof(buf), "%d", st.fps); a.push_back("-framerate"); a.push_back(buf);
+            a.push_back("-i");
+            a.push_back((std::filesystem::u8path(L.tempDir) / (L.filePrefix + "%05d.png")).u8string());
+            if (L.kind == LayerKind::Timeline) tlInput = nextInput; else simInput = nextInput;
+            ++nextInput;
+        }
+
+        // Base: fps -> scale (optionally 16:9 pillarbox) -> optionally extend canvas below.
+        std::string fg = "[0:v]fps=" + std::to_string(st.fps) + ",";
+        if (st.padTo169) {
+            stbsp_snprintf(buf, sizeof(buf),
+                "scale=%d:%d:force_original_aspect_ratio=decrease,pad=%d:%d:(ow-iw)/2:(oh-ih)/2:black",
+                outW, outH, outW, outH);
+        } else {
+            stbsp_snprintf(buf, sizeof(buf), "scale=%d:%d", outW, outH);
+        }
+        fg += buf;
+        if (bandH > 0) { stbsp_snprintf(buf, sizeof(buf), ",pad=%d:%d:0:0:black", outW, totalH); fg += buf; }
+        fg += "[base]";
+        std::string last = "[base]";
+        if (doSim) {
+            stbsp_snprintf(buf, sizeof(buf), ";%s[%d:v]overlay=%d:%d[withsim]", last.c_str(), simInput, ox, oy);
+            fg += buf; last = "[withsim]";
+        }
+        if (doTimeline) {
+            stbsp_snprintf(buf, sizeof(buf), ";%s[%d:v]overlay=0:%d[outv]", last.c_str(), tlInput, outH);
+            fg += buf; last = "[outv]";
+        }
+        a.push_back("-filter_complex"); a.push_back(fg);
         // filter_complex disables auto stream selection, so map explicitly.
-        a.push_back("-map"); a.push_back("[outv]");
+        a.push_back("-map"); a.push_back(last);
         if (st.format == 1) { a.push_back("-map"); a.push_back("0:a?"); } // source audio for AV1
     } else {
         stbsp_snprintf(buf, sizeof(buf), "fps=%d", st.fps);
@@ -249,22 +323,21 @@ void OFS_PreviewExporter::startExport(const std::string& outputPath, float start
     }
     a.push_back(outputPath);
 
-    if (doOverlay) {
+    if (needFrames) {
         // Kick off the incremental frame-render job; ffmpeg spawns when it finishes.
         int frames = (int)std::lround((double)(end - start) * st.fps);
         if (frames < 1) frames = 1;
         jobFrame = 0;
         jobFrameCount = frames;
-        jobW = ow; jobH = oh;
         jobStart = start;
         jobFps = (float)st.fps;
-        jobTempDir = tempDir;
+        jobLayers = std::move(layers);
         jobArgs = std::move(a);
         renderingFrames = true;
         exporting.store(true); // UI shows busy through the whole job
         hasRun = true;
     } else {
-        spawnFfmpeg(std::move(a), std::string());
+        spawnFfmpeg(std::move(a), {}); // no PNG sequences (e.g. plain 16:9 pad)
     }
 }
 
@@ -274,34 +347,55 @@ void OFS_PreviewExporter::Update() noexcept
     auto app = OpenFunscripter::ptr;
     auto& sim = app->GetSimulator3D();
     auto& scripts = app->LoadedFunscripts();
-    const bool use2D = PreviewExportState::State(stateHandle).sim2D;
-    const SimulatorState* sc2D = use2D ? &sim2DConfig() : nullptr;
+    const auto& st = PreviewExportState::State(stateHandle);
+    const int activeIdx = (int)app->LoadedProject->ActiveIdx();
+    const SimulatorState* sc2D = &sim2DConfig();
 
     // Render a small batch per UI frame to keep the app responsive.
     constexpr int kBatch = 4;
+    std::vector<uint8_t> textOverlay; // reused scratch for baked height text
     for (int k = 0; k < kBatch && jobFrame < jobFrameCount; ++k, ++jobFrame) {
         const float t = jobStart + (float)jobFrame / jobFps;
-        bool ok = true;
-        if (use2D) {
-            int pp, np;
-            adjacentPos(app->ActiveFunscript(), t, pp, np);
-            renderBar2D(strokeAt(app, t), pp, np, jobW, jobH, *sc2D, jobPixels);
-        } else {
-            ok = sim.RenderPoseRGBA(scripts, t, jobW, jobH, jobPixels);
-        }
-        if (ok) {
-            char name[32];
-            stbsp_snprintf(name, sizeof(name), "frame_%05d.png", jobFrame);
-            const auto p = (std::filesystem::u8path(jobTempDir) / name).u8string();
-            stbi_write_png(p.c_str(), jobW, jobH, 4, jobPixels.data(), jobW * 4);
+        char name[48];
+        for (auto& L : jobLayers) {
+            bool ok = true;
+            switch (L.kind) {
+            case LayerKind::Sim2D: {
+                int pp, np;
+                adjacentPos(app->ActiveFunscript(), t, pp, np);
+                renderBar2D(strokeAt(app, t), pp, np, L.w, L.h, *sc2D, L.pixels);
+                break;
+            }
+            case LayerKind::Sim3D:
+                ok = sim.RenderPoseRGBA(scripts, t, L.w, L.h, L.pixels);
+                break;
+            case LayerKind::Timeline:
+                ok = OFS_TimelineRaster::Render(scripts, activeIdx, t, st.timelineVisibleTime,
+                                                L.w, L.h, st.timelineShowHeightLines,
+                                                st.timelineAllScripts, L.pixels);
+                break;
+            }
+            if (ok && st.simShowHeightText && (L.kind == LayerKind::Sim2D || L.kind == LayerKind::Sim3D)) {
+                char hb[8];
+                stbsp_snprintf(hb, sizeof(hb), "%d", (int)std::lround(strokeAt(app, t) * 100.f));
+                if (OFS_TimelineRaster::RenderTextBottomCenter(hb, L.w, L.h, textOverlay))
+                    compositeOver(L.pixels, textOverlay, L.w, L.h);
+            }
+            if (ok) {
+                stbsp_snprintf(name, sizeof(name), "%s%05d.png", L.filePrefix.c_str(), jobFrame);
+                const auto p = (std::filesystem::u8path(L.tempDir) / name).u8string();
+                stbi_write_png(p.c_str(), L.w, L.h, 4, L.pixels.data(), L.w * 4);
+            }
         }
     }
 
     if (jobFrame >= jobFrameCount) {
         renderingFrames = false;
-        spawnFfmpeg(std::move(jobArgs), std::move(jobTempDir));
+        std::vector<std::string> dirs;
+        for (auto& L : jobLayers) dirs.push_back(L.tempDir);
+        spawnFfmpeg(std::move(jobArgs), std::move(dirs));
         jobArgs.clear();
-        jobTempDir.clear();
+        jobLayers.clear();
     }
 }
 
@@ -330,6 +424,14 @@ void OFS_PreviewExporter::ShowWindow(bool* open) noexcept
                 if (ImGui::Selectable(lbl, st.resolution == h)) st.resolution = h;
             }
             ImGui::EndCombo();
+        }
+    }
+
+    {
+        ImGui::Checkbox("Pad video to 16:9 (black bars)", &st.padTo169);
+        if (vw > 0 && vh > vw) {
+            ImGui::SameLine();
+            ImGui::TextDisabled("(recommended for vertical video)");
         }
     }
 
@@ -375,15 +477,32 @@ void OFS_PreviewExporter::ShowWindow(bool* open) noexcept
     if (st.overlaySim) {
         ImGui::SameLine();
         ImGui::Checkbox("2D bar (single axis)", &st.sim2D);
+        ImGui::Checkbox("Show height value", &st.simShowHeightText);
         const uint32_t frameTex = app->player->FrameTexture();
         if (frameTex && vw > 0 && vh > 0) {
-            ImGui::TextDisabled("Drag to move \xE2\x80\xA2 drag corner to resize");
+            ImGui::TextDisabled(st.padTo169
+                ? "16:9 preview \xE2\x80\xA2 drag the sim into the black bars \xE2\x80\xA2 corner to resize"
+                : "Drag to move \xE2\x80\xA2 drag corner to resize");
             float previewW = ImGui::GetContentRegionAvail().x;
             if (previewW > 480.f) previewW = 480.f;
-            const float previewH = previewW * (float)vh / (float)vw;
+            // When padding to 16:9 the drag canvas is the padded frame (so overlays can
+            // be positioned in the bars); otherwise it's the video at its native aspect.
+            const float previewH = st.padTo169 ? (previewW * 9.f / 16.f)
+                                               : (previewW * (float)vh / (float)vw);
             const ImVec2 origin = ImGui::GetCursorScreenPos();
-            ImGui::Image((ImTextureID)(intptr_t)frameTex, ImVec2(previewW, previewH));
             auto* dl = ImGui::GetWindowDrawList();
+            if (st.padTo169) {
+                // Black 16:9 canvas with the source letterboxed/pillarboxed inside, matching
+                // the exported frame so the overlay lands where the preview shows it.
+                dl->AddRectFilled(origin, ImVec2(origin.x + previewW, origin.y + previewH), IM_COL32(0, 0, 0, 255));
+                float vidW = previewW, vidH = previewW * (float)vh / (float)vw;
+                if (vidH > previewH) { vidH = previewH; vidW = previewH * (float)vw / (float)vh; }
+                const ImVec2 vMin(origin.x + (previewW - vidW) * 0.5f, origin.y + (previewH - vidH) * 0.5f);
+                dl->AddImage((ImTextureID)(intptr_t)frameTex, vMin, ImVec2(vMin.x + vidW, vMin.y + vidH));
+                ImGui::Dummy(ImVec2(previewW, previewH));
+            } else {
+                ImGui::Image((ImTextureID)(intptr_t)frameTex, ImVec2(previewW, previewH));
+            }
 
             const ImVec2 bMin(origin.x + st.simX * previewW, origin.y + st.simY * previewH);
             const int bw = (int)(st.simW * previewW);
@@ -430,6 +549,15 @@ void OFS_PreviewExporter::ShowWindow(bool* open) noexcept
                         app->LoadedFunscripts(), (float)app->player->CurrentTime(), bw, bh);
                     dl->AddImage((ImTextureID)(intptr_t)simTex, bMin, bMax, ImVec2(0, 1), ImVec2(1, 0));
                 }
+                if (st.simShowHeightText) {
+                    char b[8];
+                    stbsp_snprintf(b, sizeof(b), "%d",
+                        (int)std::lround(strokeAt(app, (float)app->player->CurrentTime()) * 100.f));
+                    const ImVec2 ts = ImGui::CalcTextSize(b);
+                    const ImVec2 tp((bMin.x + bMax.x) * 0.5f - ts.x * 0.5f, bMax.y - ts.y - 3.f);
+                    dl->AddText(ImVec2(tp.x + 1.f, tp.y + 1.f), IM_COL32(0, 0, 0, 255), b);
+                    dl->AddText(tp, IM_COL32(255, 255, 255, 255), b);
+                }
             }
             const float grip = 22.f; // easy-to-grab resize corner
             dl->AddRect(bMin, bMax, IM_COL32(0xFF, 0xE0, 0x40, 0xD0), 0.f, 0, 2.f);
@@ -468,6 +596,32 @@ void OFS_PreviewExporter::ShowWindow(bool* open) noexcept
         }
         if (app->LoadedFunscripts().empty())
             ImGui::TextDisabled("No script loaded \xE2\x80\x94 nothing to composite.");
+    }
+
+    // ---- Append the scrolling script timeline as a band below the video ----
+    ImGui::Separator();
+    ImGui::Checkbox("Append script timeline below video", &st.overlayTimeline);
+    if (st.overlayTimeline) {
+        if (ImGui::SliderFloat("Timeline window", &st.timelineVisibleTime, 1.f, 60.f, "%.1f s"))
+            st.timelineVisibleTime = Util::Clamp(st.timelineVisibleTime, 1.f, 300.f);
+        if (ImGui::SliderFloat("Strip height", &st.timelineHeightFrac, 0.05f, 0.6f, "%.2f"))
+            st.timelineHeightFrac = Util::Clamp(st.timelineHeightFrac, 0.05f, 0.6f);
+        ImGui::Checkbox("Height lines", &st.timelineShowHeightLines);
+        ImGui::Checkbox("Include all enabled scripts (multi-axis)", &st.timelineAllScripts);
+
+        if (app->LoadedFunscripts().empty()) {
+            ImGui::TextDisabled("No script loaded \xE2\x80\x94 nothing to draw.");
+        } else if (vw > 0 && vh > 0) {
+            const float previewW = Util::Min(ImGui::GetContentRegionAvail().x, 480.f);
+            const float aspect = st.padTo169 ? (9.f / 16.f) : ((float)vh / (float)vw);
+            const float stripH = previewW * aspect * st.timelineHeightFrac;
+            const ImVec2 origin = ImGui::GetCursorScreenPos();
+            OFS_TimelineRaster::DrawInto(ImGui::GetWindowDrawList(), origin, ImVec2(previewW, stripH),
+                              app->LoadedFunscripts(), (int)app->LoadedProject->ActiveIdx(),
+                              (float)app->player->CurrentTime(), st.timelineVisibleTime,
+                              st.timelineShowHeightLines, st.timelineAllScripts);
+            ImGui::Dummy(ImVec2(previewW, stripH));
+        }
     }
 
     ImGui::Separator();

--- a/src/UI/OFS_PreviewExporter.cpp
+++ b/src/UI/OFS_PreviewExporter.cpp
@@ -21,7 +21,7 @@
 #include <thread>
 #include <vector>
 
-// Even output width for a target height at the video's aspect (16:9 fallback).
+// Even output width for a target height at the video's aspect (16:9 fallback). 
 static int widthForHeight(int h, uint16_t vw, uint16_t vh) noexcept
 {
     int w = (vh > 0) ? (int)std::lround((double)vw * h / (double)vh) : (h * 16 / 9);

--- a/src/UI/OFS_PreviewExporter.h
+++ b/src/UI/OFS_PreviewExporter.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <atomic>
 #include <string>
+#include <vector>
 
 // Exports a short animated preview (WebP or AV1) of a chapter or timestamp range
 // via ffmpeg. Runs the encode on a background thread so the UI stays responsive.
@@ -18,12 +19,32 @@ private:
     std::atomic<bool> exporting{false};
     std::atomic<int> lastResult{0};
     bool hasRun = false;
+    std::string lastErrorText; // captured ffmpeg stderr on failure
 
-    void beginExport(const std::string& outputPath, float start, float end) noexcept;
+    // HH:MM:SS.mmm text buffers for the timestamp range fields.
+    std::string startStr, endStr;
+    bool startEditing = false, endEditing = false;
+    bool draggingResize = false; // true while a drag that started in the resize corner is active
+
+    // Incremental sim-frame render job (overlay). Frames are rendered a few per
+    // UI frame on the main thread (GL), then ffmpeg runs on a background thread.
+    bool renderingFrames = false;
+    int jobFrame = 0, jobFrameCount = 0;
+    int jobW = 0, jobH = 0;
+    float jobStart = 0.f, jobFps = 15.f;
+    std::string jobTempDir;
+    std::vector<std::string> jobArgs;
+    std::vector<uint8_t> jobPixels;
+
+    void startExport(const std::string& outputPath, float start, float end) noexcept;
+    void spawnFfmpeg(std::vector<std::string> args, std::string tempDir) noexcept;
 
 public:
     static constexpr const char* WindowId = "###PREVIEW_EXPORT";
 
     void Init() noexcept;
+    void Update() noexcept; // advances the frame-render job; call every frame
     void ShowWindow(bool* open) noexcept;
+    // Opens the exporter pre-set to a chapter's range (from the chapter context menu).
+    void OpenForChapter(float start, float end) noexcept;
 };

--- a/src/UI/OFS_PreviewExporter.h
+++ b/src/UI/OFS_PreviewExporter.h
@@ -36,15 +36,22 @@ private:
         std::vector<uint8_t> pixels;
     };
 
+    // A section of the source to export: [start, start+dur]. A normal export is one
+    // segment; a compilation is several spread across the media, concatenated.
+    struct Segment { float start; float dur; };
+
     // Incremental frame-render job. Each enabled layer's frame is rendered a few
     // per UI frame on the main thread (GL), then ffmpeg runs on a background thread.
+    // Output frame k maps to a source time within one segment (see Update()).
     bool renderingFrames = false;
     int jobFrame = 0, jobFrameCount = 0;
-    float jobStart = 0.f, jobFps = 15.f;
+    float jobFps = 15.f;
+    std::vector<float> jobSegStarts;   // source start time of each segment
+    int jobFramesPerSeg = 0;           // output frames per segment (equal durations)
     std::vector<ExportLayer> jobLayers;
     std::vector<std::string> jobArgs;
 
-    void startExport(const std::string& outputPath, float start, float end) noexcept;
+    void startExport(const std::string& outputPath, const std::vector<Segment>& segments) noexcept;
     void spawnFfmpeg(std::vector<std::string> args, std::vector<std::string> tempDirs) noexcept;
 
 public:

--- a/src/UI/OFS_PreviewExporter.h
+++ b/src/UI/OFS_PreviewExporter.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cstdint>
+#include <atomic>
+#include <string>
+
+// Exports a short animated preview (WebP or AV1) of a chapter or timestamp range
+// via ffmpeg. Runs the encode on a background thread so the UI stays responsive.
+// (On-video simulator compositing is a planned follow-up, not included here.)
+class OFS_PreviewExporter
+{
+private:
+    uint32_t stateHandle = 0xFFFF'FFFFu;
+    int selectedChapter = 0;
+    float startTime = 0.f;
+    float endTime = 0.f;
+
+    std::atomic<bool> exporting{false};
+    std::atomic<int> lastResult{0};
+    bool hasRun = false;
+
+    void beginExport(const std::string& outputPath, float start, float end) noexcept;
+
+public:
+    static constexpr const char* WindowId = "###PREVIEW_EXPORT";
+
+    void Init() noexcept;
+    void ShowWindow(bool* open) noexcept;
+};

--- a/src/UI/OFS_PreviewExporter.h
+++ b/src/UI/OFS_PreviewExporter.h
@@ -26,18 +26,26 @@ private:
     bool startEditing = false, endEditing = false;
     bool draggingResize = false; // true while a drag that started in the resize corner is active
 
-    // Incremental sim-frame render job (overlay). Frames are rendered a few per
-    // UI frame on the main thread (GL), then ffmpeg runs on a background thread.
+    // One compositing overlay stream (rendered to a PNG sequence, fed to ffmpeg).
+    enum class LayerKind { Sim3D, Sim2D, Timeline };
+    struct ExportLayer {
+        LayerKind kind;
+        int w = 0, h = 0;
+        std::string tempDir;    // its own frame directory
+        std::string filePrefix; // e.g. "frame_" / "tl_"
+        std::vector<uint8_t> pixels;
+    };
+
+    // Incremental frame-render job. Each enabled layer's frame is rendered a few
+    // per UI frame on the main thread (GL), then ffmpeg runs on a background thread.
     bool renderingFrames = false;
     int jobFrame = 0, jobFrameCount = 0;
-    int jobW = 0, jobH = 0;
     float jobStart = 0.f, jobFps = 15.f;
-    std::string jobTempDir;
+    std::vector<ExportLayer> jobLayers;
     std::vector<std::string> jobArgs;
-    std::vector<uint8_t> jobPixels;
 
     void startExport(const std::string& outputPath, float start, float end) noexcept;
-    void spawnFfmpeg(std::vector<std::string> args, std::string tempDir) noexcept;
+    void spawnFfmpeg(std::vector<std::string> args, std::vector<std::string> tempDirs) noexcept;
 
 public:
     static constexpr const char* WindowId = "###PREVIEW_EXPORT";

--- a/src/UI/OFS_Simulator3D.cpp
+++ b/src/UI/OFS_Simulator3D.cpp
@@ -266,6 +266,21 @@ void Simulator3D::buildMesh() noexcept
     glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 6 * sizeof(float), (void*)(3 * sizeof(float)));
     glEnableVertexAttribArray(1);
     glBindVertexArray(0);
+
+    // Thin unit vertical box (y 0..1); oriented/scaled per-frame for the stroke line.
+    std::vector<float> lineMesh;
+    appendBox(lineMesh, glm::vec3(0.f, 0.5f, 0.f), glm::vec3(0.012f, 0.5f, 0.012f));
+    lineVertCount = (int)(lineMesh.size() / 6);
+    glGenVertexArrays(1, &lineVao);
+    glBindVertexArray(lineVao);
+    glGenBuffers(1, &lineVbo);
+    glBindBuffer(GL_ARRAY_BUFFER, lineVbo);
+    glBufferData(GL_ARRAY_BUFFER, lineMesh.size() * sizeof(float), lineMesh.data(), GL_STATIC_DRAW);
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 6 * sizeof(float), (void*)0);
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 6 * sizeof(float), (void*)(3 * sizeof(float)));
+    glEnableVertexAttribArray(1);
+    glBindVertexArray(0);
 }
 
 // (Re)creates an FBO + color texture + depth renderbuffer at w x h if the size changed.
@@ -313,6 +328,7 @@ void Simulator3D::ensureExportGL(int width, int height) noexcept
     if (!shader) shader = std::make_unique<LightingShader>();
     if (!vao) buildMesh();
     ensureFboSet(exFbo, exColorTex, exDepthRbo, exWidth, exHeight, width, height);
+    ensureFboSet(ssFbo, ssColorTex, ssDepthRbo, ssWidth, ssHeight, width * 2, height * 2); // 2x supersample
 }
 
 void Simulator3D::renderMeshToTexture(uint32_t targetFbo, int w, int h, const float* model, const float* view,
@@ -358,6 +374,35 @@ void Simulator3D::renderMeshToTexture(uint32_t targetFbo, int w, int h, const fl
         glDrawArrays(GL_TRIANGLES, partOffset[i], partCount[i]);
     }
     glBindVertexArray(0);
+
+    // Stroke line: from a fixed ground anchor to the (moving/rotating) cylinder bottom,
+    // so it tilts and stretches with the device rather than staying vertical.
+    if (st.showStrokeLine && lineVertCount > 0) {
+        const glm::mat4 dm = glm::make_mat4(model);
+        const glm::vec3 top = glm::vec3(dm * glm::vec4(0.f, -0.875f, 0.f, 1.f)); // cylinder bottom
+        const glm::vec3 base(0.f, -2.f, 0.f);                                    // fixed ground anchor
+        const glm::vec3 delta = top - base;
+        const float len = glm::length(delta);
+        if (len > 1e-4f) {
+            // Orient the unit +Y box along the anchor->cylinder direction.
+            const glm::vec3 d = delta / len;
+            const glm::vec3 ref = (std::abs(d.y) > 0.99f) ? glm::vec3(1.f, 0.f, 0.f) : glm::vec3(0.f, 1.f, 0.f);
+            const glm::vec3 right = glm::normalize(glm::cross(ref, d));
+            const glm::vec3 fwd = glm::cross(d, right);
+            glm::mat4 R(1.f);
+            R[0] = glm::vec4(right, 0.f);
+            R[1] = glm::vec4(d, 0.f);
+            R[2] = glm::vec4(fwd, 0.f);
+            const glm::mat4 lineModel = glm::translate(glm::mat4(1.f), base) * R
+                * glm::scale(glm::mat4(1.f), glm::vec3(1.f, len, 1.f));
+            shader->ModelMtx(glm::value_ptr(lineModel));
+            const glm::vec4 lineCol(0.90f, 0.90f, 0.95f, 1.f);
+            shader->ObjectColor(glm::value_ptr(lineCol));
+            glBindVertexArray(lineVao);
+            glDrawArrays(GL_TRIANGLES, 0, lineVertCount);
+            glBindVertexArray(0);
+        }
+    }
 
     // Restore state.
     glBindFramebuffer(GL_FRAMEBUFFER, (GLuint)prevFbo);
@@ -414,8 +459,15 @@ uint32_t Simulator3D::RenderPoseTexture(const std::vector<std::shared_ptr<Funscr
     const glm::mat4 view = glm::lookAt(camPos, glm::vec3(0.f), glm::vec3(0.f, 1.f, 0.f));
     const glm::mat4 proj = glm::perspective(glm::radians(45.f), (float)w / (float)h, 0.1f, 100.f);
 
-    renderMeshToTexture(exFbo, exWidth, exHeight, glm::value_ptr(model), glm::value_ptr(view),
+    // Render at 2x into the supersampled FBO, then linearly downscale into exFbo (antialiasing).
+    renderMeshToTexture(ssFbo, ssWidth, ssHeight, glm::value_ptr(model), glm::value_ptr(view),
                         glm::value_ptr(proj), glm::value_ptr(camPos), /*transparent=*/true);
+    GLint prevFbo = 0;
+    glGetIntegerv(GL_FRAMEBUFFER_BINDING, &prevFbo);
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, ssFbo);
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, exFbo);
+    glBlitFramebuffer(0, 0, ssWidth, ssHeight, 0, 0, exWidth, exHeight, GL_COLOR_BUFFER_BIT, GL_LINEAR);
+    glBindFramebuffer(GL_FRAMEBUFFER, (GLuint)prevFbo);
     return exColorTex;
 }
 
@@ -466,6 +518,8 @@ void Simulator3D::ShowWindow(bool* open, const std::vector<std::shared_ptr<Funsc
         ImGui::EndDisabled();
         ImGui::SameLine();
         ImGui::Checkbox("Axis gizmo", &st.showGizmo);
+        ImGui::SameLine();
+        ImGui::Checkbox("Stroke line", &st.showStrokeLine);
 
         if (ImGui::Button("Recenter view")) {
             const Simulator3DState def{}; // reset camera to struct defaults

--- a/src/UI/OFS_Simulator3D.cpp
+++ b/src/UI/OFS_Simulator3D.cpp
@@ -211,9 +211,14 @@ static void appendCapsuleY(std::vector<float>& m, const glm::vec3& c, float r, f
 // deform + vib jitter). Shared by the interactive canvas and the export render.
 static glm::mat4 poseModel(const Pose3D& pose, float jitterTime) noexcept
 {
-    glm::mat4 rot = glm::rotate(glm::mat4(1.f), pose.ry, glm::vec3(0.f, 1.f, 0.f))
+    // Matches the reference OFS_Simulator3D, which does:
+    //   GlobalRotate(Right, pitch); GlobalRotate(Forward, roll); RotateObjectLocal(Up, twist)
+    // Godot's GlobalRotate pre-multiplies and RotateObjectLocal post-multiplies, so the
+    // composition is Rz(roll) * Rx(pitch) * Ry(twist): roll outermost, twist local/innermost
+    // (twist spins the receiver about its own shaft rather than about world up).
+    glm::mat4 rot = glm::rotate(glm::mat4(1.f), pose.rz, glm::vec3(0.f, 0.f, 1.f))
         * glm::rotate(glm::mat4(1.f), pose.rx, glm::vec3(1.f, 0.f, 0.f))
-        * glm::rotate(glm::mat4(1.f), pose.rz, glm::vec3(0.f, 0.f, 1.f));
+        * glm::rotate(glm::mat4(1.f), pose.ry, glm::vec3(0.f, 1.f, 0.f));
     glm::vec3 auxScale(1.f);
     if (pose.hasSuck) { const float s = 1.f - pose.suck * 0.35f; auxScale.x *= s; auxScale.z *= s; }
     if (pose.hasPump) { auxScale.y *= 1.f + (pose.pump * 2.f - 1.f) * 0.2f; }
@@ -430,9 +435,11 @@ Pose3D Simulator3D::samplePose(const std::vector<std::shared_ptr<Funscript>>& sc
             pose.ty = dir(st.invertStroke) * st.translateRange; pose.hasStroke = true;
             pose.stroke01 = v; // report the funscript position, not the display transform
         } else if (axis == "surge") {
-            pose.tz = dir(st.invertSurge) * st.translateRange * 0.5f; pose.hasSurge = true;
+            // Axis assignment matches the reference OFS_Simulator3D, which drives
+            // X from surge (Lerp(-0.5, 0.5)) and Z from sway (Lerp(0.5, -0.5)).
+            pose.tx = dir(st.invertSurge) * st.translateRange * 0.5f; pose.hasSurge = true;
         } else if (axis == "sway") {
-            pose.tx = -dir(st.invertSway) * st.translateRange * 0.5f; pose.hasSway = true;
+            pose.tz = -dir(st.invertSway) * st.translateRange * 0.5f; pose.hasSway = true;
         } else if (axis == "twist") {
             pose.ry = glm::radians(dir(st.invertTwist) * st.twistRange); pose.hasTwist = true;
         } else if (axis == "roll") {
@@ -541,6 +548,15 @@ void Simulator3D::ShowWindow(bool* open, const std::vector<std::shared_ptr<Funsc
             st.camPitch = def.camPitch;
             st.camDist = def.camDist;
         }
+        ImGui::SameLine();
+        if (ImGui::Button("Reset ranges")) {
+            const Simulator3DState def{}; // reference-matching motion ranges
+            st.translateRange = def.translateRange;
+            st.twistRange = def.twistRange;
+            st.rollRange = def.rollRange;
+            st.pitchRange = def.pitchRange;
+        }
+        OFS::Tooltip("Restore stroke/twist/roll/pitch ranges to the reference simulator's values.");
 
         // Range controls: slider for feel + editable box for exact values.
         auto rangeCtrl = [](const char* label, float* v, float mn, float mx) {

--- a/src/UI/OFS_Simulator3D.cpp
+++ b/src/UI/OFS_Simulator3D.cpp
@@ -435,11 +435,11 @@ Pose3D Simulator3D::samplePose(const std::vector<std::shared_ptr<Funscript>>& sc
             pose.ty = dir(st.invertStroke) * st.translateRange; pose.hasStroke = true;
             pose.stroke01 = v; // report the funscript position, not the display transform
         } else if (axis == "surge") {
-            // Axis assignment matches the reference OFS_Simulator3D, which drives
-            // X from surge (Lerp(-0.5, 0.5)) and Z from sway (Lerp(0.5, -0.5)).
-            pose.tx = dir(st.invertSurge) * st.translateRange * 0.5f; pose.hasSurge = true;
+            // Surge drives Z (toward/away from the default camera), negated like
+            // sway/roll/pitch so it moves with the same handedness as the other axes.
+            pose.tz = -dir(st.invertSurge) * st.translateRange * 0.5f; pose.hasSurge = true;
         } else if (axis == "sway") {
-            pose.tz = -dir(st.invertSway) * st.translateRange * 0.5f; pose.hasSway = true;
+            pose.tx = -dir(st.invertSway) * st.translateRange * 0.5f; pose.hasSway = true;
         } else if (axis == "twist") {
             pose.ry = glm::radians(dir(st.invertTwist) * st.twistRange); pose.hasTwist = true;
         } else if (axis == "roll") {

--- a/src/UI/OFS_Simulator3D.cpp
+++ b/src/UI/OFS_Simulator3D.cpp
@@ -6,8 +6,11 @@
 #include "OFS_Localization.h"
 #include "OFS_GL.h"
 #include "OFS_Shader.h"
+#include "OFS_ImGui.h"
+#include "OFS_DynamicFontAtlas.h"
 
 #include "imgui.h"
+#include "stb_sprintf.h"
 
 #include "glm/glm.hpp"
 #include "glm/gtc/matrix_transform.hpp"
@@ -425,6 +428,7 @@ Pose3D Simulator3D::samplePose(const std::vector<std::shared_ptr<Funscript>>& sc
 
         if (axis.empty()) {
             pose.ty = dir(st.invertStroke) * st.translateRange; pose.hasStroke = true;
+            pose.stroke01 = v; // report the funscript position, not the display transform
         } else if (axis == "surge") {
             pose.tz = dir(st.invertSurge) * st.translateRange * 0.5f; pose.hasSurge = true;
         } else if (axis == "sway") {
@@ -520,6 +524,16 @@ void Simulator3D::ShowWindow(bool* open, const std::vector<std::shared_ptr<Funsc
         ImGui::Checkbox("Axis gizmo", &st.showGizmo);
         ImGui::SameLine();
         ImGui::Checkbox("Stroke line", &st.showStrokeLine);
+        ImGui::SameLine();
+        ImGui::Checkbox("Height value", &st.showHeightText);
+        OFS::Tooltip("Show the stroke position (0-100) under the model.");
+        if (st.showHeightText) {
+            ImGui::SameLine();
+            ImGui::SetNextItemWidth(120.f);
+            if (ImGui::SliderFloat("Size##heightText", &st.heightTextScale, 0.5f, 8.f, "%.1fx"))
+                st.heightTextScale = Util::Clamp(st.heightTextScale, 0.5f, 8.f);
+            OFS::Tooltip("Readout size, relative to the UI font.");
+        }
 
         if (ImGui::Button("Recenter view")) {
             const Simulator3DState def{}; // reset camera to struct defaults
@@ -785,5 +799,22 @@ void Simulator3D::renderCanvas(Simulator3DState& st, const Pose3D& pose,
         ImVec2 ts = ImGui::CalcTextSize(msg);
         dl->AddText(ImVec2(center.x - ts.x * 0.5f, center.y - ts.y * 0.5f),
                     IM_COL32(0xAA, 0xAA, 0xAA, 0xFF), msg);
+    }
+
+    // ---- Stroke position readout, centered under the model ----
+    if (st.showHeightText && pose.hasStroke) {
+        char b[8];
+        stbsp_snprintf(b, sizeof(b), "%d", (int)std::lround(pose.stroke01 * 100.f));
+        const float fontPx = ImGui::GetFontSize() * Util::Clamp(st.heightTextScale, 0.5f, 8.f);
+        // Below the UI size the native font is sharpest; above it, scale down from
+        // the large digits face instead of upscaling the UI font (which goes soft).
+        ImFont* font = ImGui::GetFont();
+        if (OFS_DynFontAtlas::NumberFont && fontPx > ImGui::GetFontSize())
+            font = OFS_DynFontAtlas::NumberFont;
+        const ImVec2 ts = font->CalcTextSizeA(fontPx, FLT_MAX, 0.f, b);
+        const ImVec2 tp(origin.x + (size.x - ts.x) * 0.5f, origin.y + size.y - ts.y - 4.f);
+        const float sh = Util::Max(1.f, fontPx * 0.06f); // shadow offset scales with the text
+        dl->AddText(font, fontPx, ImVec2(tp.x + sh, tp.y + sh), IM_COL32(0, 0, 0, 0xC0), b);
+        dl->AddText(font, fontPx, tp, IM_COL32(0xFF, 0xFF, 0xFF, 0xFF), b);
     }
 }

--- a/src/UI/OFS_Simulator3D.cpp
+++ b/src/UI/OFS_Simulator3D.cpp
@@ -1,0 +1,735 @@
+#include "OFS_Simulator3D.h"
+#include "state/Simulator3DState.h"
+
+#include "Funscript.h"
+#include "OFS_Util.h"
+#include "OFS_Localization.h"
+#include "OFS_GL.h"
+#include "OFS_Shader.h"
+
+#include "imgui.h"
+
+#include "glm/glm.hpp"
+#include "glm/gtc/matrix_transform.hpp"
+#include "glm/gtc/type_ptr.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <string>
+#include <vector>
+#include <cstdint>
+
+static constexpr float PI = 3.14159265358979323846f;
+
+// Device presets, indexed by Simulator3DState::device.
+enum Sim3DDevice : int32_t { Dev_All = 0,
+    Dev_SR6 = 1,
+    Dev_OSR2 = 2 };
+
+// Whether a given axis is driven on the selected device. Per the TCode spec,
+// OSR2+ supports L0/R0/R1/R2 only (no surge/sway); SR6 supports the six
+// positional axes; the auxiliary channels (suck/vib/pump/raw) are separate
+// hardware, so only the generic "All axes" preset drives them.
+static bool AxisEnabled(int32_t device, const std::string& axis) noexcept
+{
+    const bool aux = (axis == "suck" || axis == "vib" || axis == "pump" || axis == "raw");
+    if (device == Dev_OSR2 && (axis == "surge" || axis == "sway")) return false;
+    if ((device == Dev_OSR2 || device == Dev_SR6) && aux) return false;
+    return true;
+}
+
+// Resolve the axis a loaded script represents from its title suffix
+// (e.g. "clip.surge" -> "surge"). Only suffixes matching a known axis name
+// count; anything else is treated as the main stroke axis.
+static std::string AxisSuffix(const std::string& title) noexcept
+{
+    auto dot = title.rfind('.');
+    if (dot == std::string::npos) return { };
+    std::string suffix = title.substr(dot + 1);
+    for (auto* name : Funscript::AxisNames) {
+        if (suffix == name) return suffix;
+    }
+    return { };
+}
+
+// --- Procedural mesh generation (interleaved position + normal, GL_TRIANGLES) ---
+// A future external-model loader would fill the same interleaved buffer instead.
+static void appendVertex(std::vector<float>& m, const glm::vec3& p, const glm::vec3& n) noexcept
+{
+    m.push_back(p.x);
+    m.push_back(p.y);
+    m.push_back(p.z);
+    m.push_back(n.x);
+    m.push_back(n.y);
+    m.push_back(n.z);
+}
+
+static void appendQuad(std::vector<float>& m, const glm::vec3& a, const glm::vec3& b, const glm::vec3& c, const glm::vec3& d, const glm::vec3& n) noexcept
+{
+    appendVertex(m, a, n);
+    appendVertex(m, b, n);
+    appendVertex(m, c, n);
+    appendVertex(m, a, n);
+    appendVertex(m, c, n);
+    appendVertex(m, d, n);
+}
+
+static void appendCylinder(std::vector<float>& m, float y0, float y1, float r, int seg) noexcept
+{
+    for (int i = 0; i < seg; ++i) {
+        const float a0 = (float)i / seg * 2.f * PI;
+        const float a1 = (float)(i + 1) / seg * 2.f * PI;
+        const glm::vec3 n0(std::cos(a0), 0.f, std::sin(a0));
+        const glm::vec3 n1(std::cos(a1), 0.f, std::sin(a1));
+        const glm::vec3 p00 = glm::vec3(r * n0.x, y0, r * n0.z);
+        const glm::vec3 p01 = glm::vec3(r * n0.x, y1, r * n0.z);
+        const glm::vec3 p10 = glm::vec3(r * n1.x, y0, r * n1.z);
+        const glm::vec3 p11 = glm::vec3(r * n1.x, y1, r * n1.z);
+        // side (smooth radial normals)
+        appendVertex(m, p00, n0);
+        appendVertex(m, p10, n1);
+        appendVertex(m, p11, n1);
+        appendVertex(m, p00, n0);
+        appendVertex(m, p11, n1);
+        appendVertex(m, p01, n0);
+        // caps
+        appendVertex(m, glm::vec3(0, y1, 0), glm::vec3(0, 1, 0));
+        appendVertex(m, p01, glm::vec3(0, 1, 0));
+        appendVertex(m, p11, glm::vec3(0, 1, 0));
+        appendVertex(m, glm::vec3(0, y0, 0), glm::vec3(0, -1, 0));
+        appendVertex(m, p10, glm::vec3(0, -1, 0));
+        appendVertex(m, p00, glm::vec3(0, -1, 0));
+    }
+}
+
+static void appendBox(std::vector<float>& m, const glm::vec3& c, const glm::vec3& h) noexcept
+{
+    const glm::vec3 v[8] = {
+        c + glm::vec3(-h.x, -h.y, -h.z),
+        c + glm::vec3(h.x, -h.y, -h.z),
+        c + glm::vec3(h.x, h.y, -h.z),
+        c + glm::vec3(-h.x, h.y, -h.z),
+        c + glm::vec3(-h.x, -h.y, h.z),
+        c + glm::vec3(h.x, -h.y, h.z),
+        c + glm::vec3(h.x, h.y, h.z),
+        c + glm::vec3(-h.x, h.y, h.z),
+    };
+    appendQuad(m, v[4], v[5], v[6], v[7], glm::vec3(0, 0, 1));
+    appendQuad(m, v[1], v[0], v[3], v[2], glm::vec3(0, 0, -1));
+    appendQuad(m, v[5], v[1], v[2], v[6], glm::vec3(1, 0, 0));
+    appendQuad(m, v[0], v[4], v[7], v[3], glm::vec3(-1, 0, 0));
+    appendQuad(m, v[3], v[2], v[6], v[7], glm::vec3(0, 1, 0));
+    appendQuad(m, v[0], v[1], v[5], v[4], glm::vec3(0, -1, 0));
+}
+
+// Capsule aligned to the Z axis (points forward), cylinder body + hemisphere caps.
+static void appendCapsuleZ(std::vector<float>& m, const glm::vec3& c, float r, float hh, int seg, int rings) noexcept
+{
+    for (int i = 0; i < seg; ++i) { // cylinder body (radial normals in XY)
+        const float a0 = (float)i / seg * 2.f * PI;
+        const float a1 = (float)(i + 1) / seg * 2.f * PI;
+        const glm::vec3 n0(std::cos(a0), std::sin(a0), 0.f);
+        const glm::vec3 n1(std::cos(a1), std::sin(a1), 0.f);
+        const glm::vec3 f0 = c + glm::vec3(0, 0, hh) + r * n0, k0 = c + glm::vec3(0, 0, -hh) + r * n0;
+        const glm::vec3 f1 = c + glm::vec3(0, 0, hh) + r * n1, k1 = c + glm::vec3(0, 0, -hh) + r * n1;
+        appendVertex(m, k0, n0);
+        appendVertex(m, k1, n1);
+        appendVertex(m, f1, n1);
+        appendVertex(m, k0, n0);
+        appendVertex(m, f1, n1);
+        appendVertex(m, f0, n0);
+    }
+    auto hemi = [&](float sz) { // sz = +1 front, -1 back
+        const glm::vec3 capC = c + glm::vec3(0, 0, sz * hh);
+        auto V = [sz](float phi, float a) {
+            return glm::vec3(std::cos(phi) * std::cos(a), std::cos(phi) * std::sin(a), sz * std::sin(phi));
+        };
+        for (int j = 0; j < rings; ++j) {
+            const float p0 = (float)j / rings * (PI * 0.5f);
+            const float p1 = (float)(j + 1) / rings * (PI * 0.5f);
+            for (int i = 0; i < seg; ++i) {
+                const float a0 = (float)i / seg * 2.f * PI;
+                const float a1 = (float)(i + 1) / seg * 2.f * PI;
+                const glm::vec3 n00 = V(p0, a0), n01 = V(p0, a1), n11 = V(p1, a1), n10 = V(p1, a0);
+                appendVertex(m, capC + r * n00, n00);
+                appendVertex(m, capC + r * n01, n01);
+                appendVertex(m, capC + r * n11, n11);
+                appendVertex(m, capC + r * n00, n00);
+                appendVertex(m, capC + r * n11, n11);
+                appendVertex(m, capC + r * n10, n10);
+            }
+        }
+    };
+    hemi(1.f);
+    hemi(-1.f);
+}
+
+// Capsule along Y. `scale` stretches the shape per-axis (e.g. wide X + thin Z
+// for a flat tongue); positions are scaled and normals inverse-scaled to stay correct.
+static void appendCapsuleY(std::vector<float>& m, const glm::vec3& c, float r, float hh, int seg, int rings,
+                           const glm::vec3& scale = glm::vec3(1.f)) noexcept
+{
+    // off = offset from center c
+    auto push = [&](const glm::vec3& off, const glm::vec3& n) {
+        appendVertex(m, c + scale * off, glm::normalize(n / scale));
+    };
+    for (int i = 0; i < seg; ++i) { // cylinder body
+        const float a0 = (float)i / seg * 2.f * PI;
+        const float a1 = (float)(i + 1) / seg * 2.f * PI;
+        const glm::vec3 n0(std::cos(a0), 0.f, std::sin(a0));
+        const glm::vec3 n1(std::cos(a1), 0.f, std::sin(a1));
+        const glm::vec3 t(0.f, hh, 0.f), b(0.f, -hh, 0.f);
+        push(b + r * n0, n0); push(b + r * n1, n1); push(t + r * n1, n1);
+        push(b + r * n0, n0); push(t + r * n1, n1); push(t + r * n0, n0);
+    }
+    auto hemi = [&](float sy) { // sy = +1 top, -1 bottom
+        const glm::vec3 capO(0.f, sy * hh, 0.f);
+        auto V = [sy](float phi, float a) {
+            return glm::vec3(std::cos(phi) * std::cos(a), sy * std::sin(phi), std::cos(phi) * std::sin(a));
+        };
+        for (int j = 0; j < rings; ++j) {
+            const float p0 = (float)j / rings * (PI * 0.5f);
+            const float p1 = (float)(j + 1) / rings * (PI * 0.5f);
+            for (int i = 0; i < seg; ++i) {
+                const float a0 = (float)i / seg * 2.f * PI;
+                const float a1 = (float)(i + 1) / seg * 2.f * PI;
+                const glm::vec3 n00 = V(p0, a0), n01 = V(p0, a1), n11 = V(p1, a1), n10 = V(p1, a0);
+                push(capO + r * n00, n00); push(capO + r * n01, n01); push(capO + r * n11, n11);
+                push(capO + r * n00, n00); push(capO + r * n11, n11); push(capO + r * n10, n10);
+            }
+        }
+    };
+    hemi(1.f);
+    hemi(-1.f);
+}
+
+// Builds the device model matrix from a sampled pose (rotation + aux-axis
+// deform + vib jitter). Shared by the interactive canvas and the export render.
+static glm::mat4 poseModel(const Pose3D& pose, float jitterTime) noexcept
+{
+    glm::mat4 rot = glm::rotate(glm::mat4(1.f), pose.ry, glm::vec3(0.f, 1.f, 0.f))
+        * glm::rotate(glm::mat4(1.f), pose.rx, glm::vec3(1.f, 0.f, 0.f))
+        * glm::rotate(glm::mat4(1.f), pose.rz, glm::vec3(0.f, 0.f, 1.f));
+    glm::vec3 auxScale(1.f);
+    if (pose.hasSuck) { const float s = 1.f - pose.suck * 0.35f; auxScale.x *= s; auxScale.z *= s; }
+    if (pose.hasPump) { auxScale.y *= 1.f + (pose.pump * 2.f - 1.f) * 0.2f; }
+    glm::vec3 vibJitter(0.f);
+    if (pose.hasVib) {
+        const float amp = pose.vib * 0.04f;
+        vibJitter.x = std::sin(jitterTime * 47.f) * amp;
+        vibJitter.z = std::sin(jitterTime * 39.f) * amp;
+    }
+    return glm::translate(glm::mat4(1.f), glm::vec3(pose.tx, pose.ty, pose.tz) + vibJitter)
+        * rot * glm::scale(glm::mat4(1.f), auxScale);
+}
+
+Simulator3D::Simulator3D() noexcept = default;
+Simulator3D::~Simulator3D() noexcept = default;
+
+void Simulator3D::Init() noexcept
+{
+    stateHandle = OFS_AppState<Simulator3DState>::Register(Simulator3DState::StateName);
+}
+
+void Simulator3D::buildMesh() noexcept
+{
+    std::vector<float> mesh;
+    // Match the industry-standard OFS_Simulator3D primitives: a stroker cylinder
+    // plus two opposing twist-marker cubes (red left / purple right) so twist reads.
+    const int v0 = 0;
+    appendCylinder(mesh, -0.875f, 0.875f, 0.5f, 32);               // stroker (r0.5, height 1.75)
+    const int v1 = (int)(mesh.size() / 6);
+    appendBox(mesh, glm::vec3(-0.5f, 0.f, 0.f), glm::vec3(0.125f)); // twist marker L
+    const int v2 = (int)(mesh.size() / 6);
+    appendBox(mesh, glm::vec3(0.5f, 0.f, 0.f), glm::vec3(0.125f));  // twist marker R
+    const int v3 = (int)(mesh.size() / 6);
+    appendCapsuleY(mesh, glm::vec3(0.f, -0.90f, -0.4f), 0.18f, 0.22f, 20, 6,
+                   glm::vec3(1.5f, 1.0f, 0.4f)); // tongue (back-bottom-center, wide & flat)
+    const int v4 = (int)(mesh.size() / 6);
+    appendBox(mesh, glm::vec3(0.f, 0.f, 0.5f), glm::vec3(0.11f));   // center indicator (front)
+    const int v5 = (int)(mesh.size() / 6);
+    partOffset[0] = v0; partCount[0] = v1 - v0; // shaft (stroker)
+    partOffset[1] = v1; partCount[1] = v2 - v1; // twist L
+    partOffset[2] = v2; partCount[2] = v3 - v2; // twist R
+    partOffset[3] = v3; partCount[3] = v4 - v3; // tongue
+    partOffset[4] = v4; partCount[4] = v5 - v4; // center
+    meshVertexCount = v5;
+
+    glGenVertexArrays(1, &vao);
+    glBindVertexArray(vao);
+    glGenBuffers(1, &vbo);
+    glBindBuffer(GL_ARRAY_BUFFER, vbo);
+    glBufferData(GL_ARRAY_BUFFER, mesh.size() * sizeof(float), mesh.data(), GL_STATIC_DRAW);
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 6 * sizeof(float), (void*)0);
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 6 * sizeof(float), (void*)(3 * sizeof(float)));
+    glEnableVertexAttribArray(1);
+    glBindVertexArray(0);
+}
+
+// (Re)creates an FBO + color texture + depth renderbuffer at w x h if the size changed.
+static void ensureFboSet(uint32_t& fbo, uint32_t& colorTex, uint32_t& depthRbo,
+                         int& curW, int& curH, int w, int h) noexcept
+{
+    if (fbo && w == curW && h == curH) return;
+    if (fbo) {
+        glDeleteFramebuffers(1, &fbo);
+        glDeleteTextures(1, &colorTex);
+        glDeleteRenderbuffers(1, &depthRbo);
+    }
+
+    glGenFramebuffers(1, &fbo);
+    glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+
+    glGenTextures(1, &colorTex);
+    glBindTexture(GL_TEXTURE_2D, colorTex);
+    glTexImage2D(GL_TEXTURE_2D, 0, OFS_InternalTexFormat, w, h, 0, OFS_TexFormat, GL_UNSIGNED_BYTE, 0);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, colorTex, 0);
+
+    glGenRenderbuffers(1, &depthRbo);
+    glBindRenderbuffer(GL_RENDERBUFFER, depthRbo);
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, w, h);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depthRbo);
+
+    curW = w;
+    curH = h;
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}
+
+void Simulator3D::ensureGL(int width, int height) noexcept
+{
+    if (!shader) shader = std::make_unique<LightingShader>();
+    if (!vao) buildMesh();
+    ensureFboSet(fbo, colorTex, depthRbo, fbWidth, fbHeight, width, height);
+}
+
+void Simulator3D::ensureExportGL(int width, int height) noexcept
+{
+    if (!shader) shader = std::make_unique<LightingShader>();
+    if (!vao) buildMesh();
+    ensureFboSet(exFbo, exColorTex, exDepthRbo, exWidth, exHeight, width, height);
+}
+
+void Simulator3D::renderMeshToTexture(uint32_t targetFbo, int w, int h, const float* model, const float* view,
+                                      const float* proj, const float* camPos, bool transparent) noexcept
+{
+    // Save global GL state we touch so we never corrupt ImGui's own rendering.
+    GLint prevFbo = 0, prevViewport[4] = {0, 0, 0, 0};
+    GLboolean prevDepth = glIsEnabled(GL_DEPTH_TEST);
+    glGetIntegerv(GL_FRAMEBUFFER_BINDING, &prevFbo);
+    glGetIntegerv(GL_VIEWPORT, prevViewport);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, targetFbo);
+    glViewport(0, 0, w, h);
+    // Transparent clear when compositing (overlay / export) so only the model shows.
+    if (transparent)
+        glClearColor(0.f, 0.f, 0.f, 0.f);
+    else
+        glClearColor(0.06f, 0.06f, 0.07f, 1.f);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    glEnable(GL_DEPTH_TEST);
+
+    shader->Use();
+    shader->ModelMtx(model);
+    shader->ViewMtx(view);
+    shader->ProjectionMtx(proj);
+    shader->ViewPos(camPos);
+    shader->LightPos(glm::value_ptr(glm::vec3(2.5f, 4.f, 3.f)));
+    // lightColor has no public setter; set it directly so lighting is never black.
+    const glm::vec3 lightColor(1.f, 1.f, 1.f);
+    glUniform3fv(glGetUniformLocation(shader->Handle(), "lightColor"), 1, glm::value_ptr(lightColor));
+
+    // Draw each part with its own color.
+    auto& st = Simulator3DState::State(stateHandle);
+    // part order: shaft, twist L (marker), twist R (base), tongue, center
+    const ImColor* partColors[PartCount] = { &st.shaftColor, &st.markerColor, &st.baseColor,
+                                             &st.tongueColor, &st.centerColor };
+    glBindVertexArray(vao);
+    for (int i = 0; i < PartCount; ++i) {
+        if (partCount[i] <= 0) continue;
+        if (i == 3 && !st.showTongue) continue; // tongue is optional
+        if (i == 4 && !st.showCenter) continue; // center indicator is optional
+        shader->ObjectColor(&partColors[i]->Value.x);
+        glDrawArrays(GL_TRIANGLES, partOffset[i], partCount[i]);
+    }
+    glBindVertexArray(0);
+
+    // Restore state.
+    glBindFramebuffer(GL_FRAMEBUFFER, (GLuint)prevFbo);
+    glViewport(prevViewport[0], prevViewport[1], prevViewport[2], prevViewport[3]);
+    if (!prevDepth) glDisable(GL_DEPTH_TEST);
+}
+
+Pose3D Simulator3D::samplePose(const std::vector<std::shared_ptr<Funscript>>& scripts, float time) noexcept
+{
+    auto& st = Simulator3DState::State(stateHandle);
+    Pose3D pose;
+    for (auto& script : scripts) {
+        if (!script) continue;
+        const std::string axis = AxisSuffix(script->Title());
+        if (!AxisEnabled(st.device, axis)) continue; // device doesn't drive this axis
+        // Center (50) when the channel has no actions, matching how a device rests.
+        const float v = script->Actions().empty() ? 0.5f : (script->GetPositionAtTime(time) / 100.f); // 0..1
+        const float bipolar = v * 2.f - 1.f;
+        auto dir = [bipolar](bool invert) { return invert ? -bipolar : bipolar; };
+
+        if (axis.empty()) {
+            pose.ty = dir(st.invertStroke) * st.translateRange; pose.hasStroke = true;
+        } else if (axis == "surge") {
+            pose.tz = dir(st.invertSurge) * st.translateRange * 0.5f; pose.hasSurge = true;
+        } else if (axis == "sway") {
+            pose.tx = -dir(st.invertSway) * st.translateRange * 0.5f; pose.hasSway = true;
+        } else if (axis == "twist") {
+            pose.ry = glm::radians(dir(st.invertTwist) * st.twistRange); pose.hasTwist = true;
+        } else if (axis == "roll") {
+            pose.rz = -glm::radians(dir(st.invertRoll) * st.rollRange); pose.hasRoll = true;
+        } else if (axis == "pitch") {
+            pose.rx = -glm::radians(dir(st.invertPitch) * st.pitchRange); pose.hasPitch = true;
+        } else if (axis == "suck") {
+            pose.suck = v; pose.hasSuck = true;
+        } else if (axis == "vib") {
+            pose.vib = v; pose.hasVib = true;
+        } else if (axis == "pump") {
+            pose.pump = v; pose.hasPump = true;
+        }
+    }
+    return pose;
+}
+
+uint32_t Simulator3D::RenderPoseTexture(const std::vector<std::shared_ptr<Funscript>>& scripts, float time, int w, int h) noexcept
+{
+    if (w < 1) w = 1;
+    if (h < 1) h = 1;
+    ensureExportGL(w, h);
+
+    const Pose3D pose = samplePose(scripts, time);
+    const glm::mat4 model = poseModel(pose, time); // frame time -> deterministic jitter
+    auto& st = Simulator3DState::State(stateHandle);
+    const glm::vec3 camPos = st.camDist * glm::vec3(0.f, 0.f, 1.f); // front-locked (yaw=pitch=0)
+    const glm::mat4 view = glm::lookAt(camPos, glm::vec3(0.f), glm::vec3(0.f, 1.f, 0.f));
+    const glm::mat4 proj = glm::perspective(glm::radians(45.f), (float)w / (float)h, 0.1f, 100.f);
+
+    renderMeshToTexture(exFbo, exWidth, exHeight, glm::value_ptr(model), glm::value_ptr(view),
+                        glm::value_ptr(proj), glm::value_ptr(camPos), /*transparent=*/true);
+    return exColorTex;
+}
+
+bool Simulator3D::RenderPoseRGBA(const std::vector<std::shared_ptr<Funscript>>& scripts, float time, int w, int h,
+                                 std::vector<uint8_t>& outRGBA) noexcept
+{
+    if (w < 1 || h < 1) return false;
+    RenderPoseTexture(scripts, time, w, h);
+
+    outRGBA.resize((size_t)w * (size_t)h * 4u);
+    GLint prevFbo = 0;
+    glGetIntegerv(GL_FRAMEBUFFER_BINDING, &prevFbo);
+    glBindFramebuffer(GL_FRAMEBUFFER, exFbo);
+    glReadPixels(0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, outRGBA.data());
+    glBindFramebuffer(GL_FRAMEBUFFER, (GLuint)prevFbo);
+
+    // glReadPixels is bottom-up; flip to top-down for image writing.
+    const size_t stride = (size_t)w * 4u;
+    for (int y = 0; y < h / 2; ++y) {
+        uint8_t* a = outRGBA.data() + (size_t)y * stride;
+        uint8_t* b = outRGBA.data() + (size_t)(h - 1 - y) * stride;
+        std::swap_ranges(a, a + stride, b);
+    }
+    return true;
+}
+
+void Simulator3D::ShowWindow(bool* open, const std::vector<std::shared_ptr<Funscript>>& scripts, float currentTime) noexcept
+{
+    if (!*open) return;
+    OFS_PROFILE(__FUNCTION__);
+
+    auto& st = Simulator3DState::State(stateHandle);
+
+    ImGui::Begin(TR_ID(WindowId, Tr::SIMULATOR_3D), open, ImGuiWindowFlags_None);
+
+    // ---- Sample the loaded axes into a single rigid-body pose ----
+    Pose3D pose = samplePose(scripts, currentTime);
+
+    // ---- Controls / readout (kept above the canvas so it fills the rest) ----
+    if (ImGui::CollapsingHeader("Options")) {
+        ImGui::TextDisabled("Drag to orbit \xE2\x80\xA2 scroll to zoom");
+        ImGui::Combo("Device", &st.device, "All axes\0SR6\0OSR2+\0\0");
+        ImGui::Checkbox("Lit 3D (GPU)", &st.litMode);
+        ImGui::SameLine();
+        ImGui::Checkbox("Overlay on video", &st.overlayMode);
+        ImGui::BeginDisabled(st.litMode);
+        ImGui::Checkbox("Ground grid", &st.showGrid);
+        ImGui::EndDisabled();
+        ImGui::SameLine();
+        ImGui::Checkbox("Axis gizmo", &st.showGizmo);
+
+        if (ImGui::Button("Recenter view")) {
+            const Simulator3DState def{}; // reset camera to struct defaults
+            st.camYaw = def.camYaw;
+            st.camPitch = def.camPitch;
+            st.camDist = def.camDist;
+        }
+
+        // Range controls: slider for feel + editable box for exact values.
+        auto rangeCtrl = [](const char* label, float* v, float mn, float mx) {
+            ImGui::PushID(label);
+            ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x * 0.5f);
+            ImGui::SliderFloat("##s", v, mn, mx);
+            ImGui::SameLine();
+            ImGui::SetNextItemWidth(70.f);
+            if (ImGui::InputFloat("##i", v, 0.f, 0.f, "%.2f"))
+                *v = Util::Clamp(*v, mn, mx);
+            ImGui::SameLine();
+            ImGui::TextUnformatted(label);
+            ImGui::PopID();
+        };
+        rangeCtrl("Translate range", &st.translateRange, 0.2f, 3.f);
+        rangeCtrl("Twist range", &st.twistRange, 0.f, 180.f);
+        rangeCtrl("Roll range", &st.rollRange, 0.f, 90.f);
+        rangeCtrl("Pitch range", &st.pitchRange, 0.f, 90.f);
+
+        ImGui::Separator();
+        ImGui::TextDisabled("Part colors");
+        ImGui::ColorEdit3("Shaft", &st.shaftColor.Value.x, ImGuiColorEditFlags_NoInputs);
+        ImGui::SameLine();
+        ImGui::ColorEdit3("Twist L", &st.markerColor.Value.x, ImGuiColorEditFlags_NoInputs);
+        ImGui::SameLine();
+        ImGui::ColorEdit3("Twist R", &st.baseColor.Value.x, ImGuiColorEditFlags_NoInputs);
+
+        ImGui::Checkbox("Tongue", &st.showTongue);
+        ImGui::SameLine();
+        ImGui::ColorEdit3("##tongueCol", &st.tongueColor.Value.x, ImGuiColorEditFlags_NoInputs);
+        ImGui::SameLine();
+        ImGui::Checkbox("Center", &st.showCenter);
+        ImGui::SameLine();
+        ImGui::ColorEdit3("##centerCol", &st.centerColor.Value.x, ImGuiColorEditFlags_NoInputs);
+
+        ImGui::Separator();
+        ImGui::TextDisabled("Invert axis");
+        auto invert = [&](const char* label, const char* axis, bool* flag) {
+            ImGui::BeginDisabled(!AxisEnabled(st.device, axis));
+            ImGui::Checkbox(label, flag);
+            ImGui::EndDisabled();
+        };
+        invert("stroke L0##inv", "", &st.invertStroke);   ImGui::SameLine();
+        invert("surge L1##inv", "surge", &st.invertSurge); ImGui::SameLine();
+        invert("sway L2##inv", "sway", &st.invertSway);
+        invert("twist R0##inv", "twist", &st.invertTwist); ImGui::SameLine();
+        invert("roll R1##inv", "roll", &st.invertRoll);   ImGui::SameLine();
+        invert("pitch R2##inv", "pitch", &st.invertPitch);
+
+        ImGui::Separator();
+        ImGui::TextDisabled("Active axes");
+        auto axisLabel = [](const char* name, bool active) {
+            ImGui::TextColored(active ? ImVec4(1, 1, 1, 1) : ImVec4(0.5f, 0.5f, 0.5f, 1), "%s", name);
+        };
+        axisLabel("stroke", pose.hasStroke); ImGui::SameLine();
+        axisLabel("surge", pose.hasSurge);   ImGui::SameLine();
+        axisLabel("sway", pose.hasSway);     ImGui::SameLine();
+        axisLabel("twist", pose.hasTwist);   ImGui::SameLine();
+        axisLabel("roll", pose.hasRoll);     ImGui::SameLine();
+        axisLabel("pitch", pose.hasPitch);
+        axisLabel("suck", pose.hasSuck);     ImGui::SameLine();
+        axisLabel("vib", pose.hasVib);       ImGui::SameLine();
+        axisLabel("pump", pose.hasPump);
+    }
+
+    if (!st.overlayMode) {
+        renderCanvas(st, pose, scripts, false);
+    } else {
+        ImGui::TextDisabled("Shown as an overlay on the video.");
+        ImGui::TextDisabled("Uncheck \"Overlay on video\" to dock it here.");
+    }
+
+    ImGui::End();
+
+    // Floating, borderless overlay drawn over the video. No title bar: drag the
+    // body to move, drag the bottom-right corner to resize. A thin frame + resize
+    // corner fade in on hover for discoverability; otherwise only the model shows.
+    if (st.overlayMode) {
+        ImGui::SetNextWindowSize(ImVec2(320.f, 320.f), ImGuiCond_FirstUseEver);
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.f, 0.f));
+        if (ImGui::Begin("###SIMULATOR_3D_OVERLAY", nullptr,
+                ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoDocking
+                | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse
+                | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoCollapse)) {
+            renderCanvas(st, pose, scripts, true);
+
+            if (ImGui::IsWindowHovered(ImGuiHoveredFlags_AllowWhenBlockedByActiveItem)) {
+                const ImVec2 p = ImGui::GetWindowPos();
+                const ImVec2 s = ImGui::GetWindowSize();
+                const ImVec2 br(p.x + s.x, p.y + s.y);
+                auto* fdl = ImGui::GetForegroundDrawList();
+                fdl->AddRect(p, br, IM_COL32(0xFF, 0xFF, 0xFF, 0x66), 2.f, 0, 1.5f);
+                fdl->AddTriangleFilled(ImVec2(br.x - 14.f, br.y), br, ImVec2(br.x, br.y - 14.f),
+                                       IM_COL32(0xFF, 0xFF, 0xFF, 0x99));
+            }
+        }
+        ImGui::End();
+        ImGui::PopStyleVar();
+    }
+}
+
+void Simulator3D::renderCanvas(Simulator3DState& st, const Pose3D& pose,
+                               const std::vector<std::shared_ptr<Funscript>>& scripts, bool overlay) noexcept
+{
+    ImVec2 origin = ImGui::GetCursorScreenPos();
+    ImVec2 size = ImGui::GetContentRegionAvail();
+    if (size.y < 80.f) size.y = 80.f;
+    if (size.x < 80.f) size.x = 80.f;
+
+    auto& io = ImGui::GetIO();
+    auto applyZoom = [&]() {
+        if (io.MouseWheel != 0.f) {
+            st.camDist *= (1.f - io.MouseWheel * 0.1f);
+            st.camDist = Util::Clamp(st.camDist, 1.5f, 25.f);
+        }
+    };
+    if (!overlay) {
+        ImGui::InvisibleButton("##canvas3d", size);
+        if (ImGui::IsItemActive()) {
+            st.camYaw -= io.MouseDelta.x * 0.01f;
+            st.camPitch += io.MouseDelta.y * 0.01f;
+            st.camPitch = Util::Clamp(st.camPitch, -1.45f, 1.45f);
+        }
+        if (ImGui::IsItemHovered()) applyZoom();
+    } else {
+        ImGui::Dummy(size); // reserve space without capturing drag, so the overlay window stays movable
+        if (ImGui::IsWindowHovered()) applyZoom(); // zoom (but not orbit) while hovering the overlay
+    }
+
+    auto* dl = ImGui::GetWindowDrawList();
+
+    // ---- Build matrices ----
+    const float yaw = overlay ? 0.f : st.camYaw;     // overlay locks front-and-center
+    const float pitch = overlay ? 0.f : st.camPitch;
+    const float aspect = size.x / size.y;
+    glm::vec3 camPos = st.camDist * glm::vec3(
+        std::cos(pitch) * std::sin(yaw),
+        std::sin(pitch),
+        std::cos(pitch) * std::cos(yaw));
+
+    glm::mat4 model = poseModel(pose, (float)ImGui::GetTime());
+    glm::mat4 view = glm::lookAt(camPos, glm::vec3(0.f), glm::vec3(0.f, 1.f, 0.f));
+    glm::mat4 proj = glm::perspective(glm::radians(45.f), aspect, 0.1f, 100.f);
+    glm::mat4 mv = view * model;
+    glm::mat4 mvp = proj * mv;
+
+    auto projectVP = [&](const glm::mat4& m, const glm::vec3& p, ImVec2& out) -> bool {
+        glm::vec4 clip = m * glm::vec4(p, 1.f);
+        if (clip.w <= 0.0001f) return false;
+        glm::vec3 ndc = glm::vec3(clip) / clip.w;
+        out = ImVec2(origin.x + (ndc.x * 0.5f + 0.5f) * size.x,
+                     origin.y + (1.f - (ndc.y * 0.5f + 0.5f)) * size.y);
+        return true;
+    };
+    auto project = [&](const glm::vec3& p, ImVec2& out) { return projectVP(mvp, p, out); };
+
+    bool anyDrawn = false;
+
+    if (st.litMode) {
+        // ---- GPU path: render the lit mesh to a texture, blit into the canvas ----
+        ensureGL((int)size.x, (int)size.y);
+        renderMeshToTexture(fbo, fbWidth, fbHeight, glm::value_ptr(model), glm::value_ptr(view),
+                            glm::value_ptr(proj), glm::value_ptr(camPos), /*transparent=*/overlay);
+        // FBO textures are bottom-up, so flip V.
+        dl->AddImage((ImTextureID)(intptr_t)colorTex, origin, origin + size,
+                     ImVec2(0, 1), ImVec2(1, 0));
+        anyDrawn = meshVertexCount > 0;
+    } else {
+        // ---- Fast path: flat box + optional grid through the draw list ----
+        if (!overlay) // transparent over the video in overlay mode
+            dl->AddRectFilled(origin, origin + size, IM_COL32(0x10, 0x10, 0x10, 0xFF), 4.f);
+        dl->PushClipRect(origin, origin + size, true);
+
+        if (st.showGrid && !overlay) {
+            const glm::mat4 gridVP = proj * view;
+            const float floorY = -2.f;
+            const int lines = 10;
+            const float step = 0.5f;
+            const float ext = lines * step * 0.5f;
+            const ImU32 gcol = IM_COL32(0x44, 0x4A, 0x50, 0xFF);
+            for (int i = 0; i <= lines; ++i) {
+                const float t = -ext + i * step;
+                ImVec2 a, b;
+                if (projectVP(gridVP, glm::vec3(t, floorY, -ext), a) && projectVP(gridVP, glm::vec3(t, floorY, ext), b))
+                    dl->AddLine(a, b, gcol, 1.f);
+                if (projectVP(gridVP, glm::vec3(-ext, floorY, t), a) && projectVP(gridVP, glm::vec3(ext, floorY, t), b))
+                    dl->AddLine(a, b, gcol, 1.f);
+            }
+        }
+
+        const glm::vec3 he(0.6f, 0.9f, 0.6f);
+        const std::array<glm::vec3, 8> corners = {{
+            {-he.x, -he.y, -he.z}, { he.x, -he.y, -he.z}, { he.x,  he.y, -he.z}, {-he.x,  he.y, -he.z},
+            {-he.x, -he.y,  he.z}, { he.x, -he.y,  he.z}, { he.x,  he.y,  he.z}, {-he.x,  he.y,  he.z},
+        }};
+        struct Face { int idx[4]; glm::vec3 normal; ImU32 color; };
+        const ImU32 sideCol = st.shaftColor;  // sides = shaft
+        const ImU32 topCol  = st.markerColor; // top   = marker
+        const ImU32 botCol  = st.baseColor;   // bottom = base
+        const std::array<Face, 6> faces = {{
+            {{4, 5, 6, 7}, { 0,  0,  1}, sideCol}, {{1, 0, 3, 2}, { 0,  0, -1}, sideCol},
+            {{5, 1, 2, 6}, { 1,  0,  0}, sideCol}, {{0, 4, 7, 3}, {-1,  0,  0}, sideCol},
+            {{3, 7, 6, 2}, { 0,  1,  0}, topCol }, {{0, 1, 5, 4}, { 0, -1,  0}, botCol },
+        }};
+        const glm::mat3 normalMat = glm::mat3(model);
+        const glm::vec3 lightDir = glm::normalize(glm::vec3(0.4f, 0.8f, 0.6f));
+
+        std::array<int, 6> order = {0, 1, 2, 3, 4, 5};
+        std::array<float, 6> depth{};
+        for (int f = 0; f < 6; ++f) {
+            float z = 0.f;
+            for (int k = 0; k < 4; ++k)
+                z += (mv * glm::vec4(corners[faces[f].idx[k]], 1.f)).z;
+            depth[f] = z * 0.25f;
+        }
+        std::sort(order.begin(), order.end(), [&](int a, int b) { return depth[a] < depth[b]; });
+
+        for (int f : order) {
+            const Face& face = faces[f];
+            ImVec2 pts[4];
+            bool ok = true;
+            for (int k = 0; k < 4 && ok; ++k)
+                ok = project(corners[face.idx[k]], pts[k]);
+            if (!ok) continue;
+            glm::vec3 n = glm::normalize(normalMat * face.normal);
+            float shade = 0.35f + 0.65f * std::max(0.f, glm::dot(n, lightDir));
+            ImU32 c = face.color;
+            auto scale = [&](int shift) { return (ImU32)(((c >> shift) & 0xFF) * shade); };
+            ImU32 shaded = IM_COL32(scale(IM_COL32_R_SHIFT), scale(IM_COL32_G_SHIFT), scale(IM_COL32_B_SHIFT), 0xFF);
+            dl->AddQuadFilled(pts[0], pts[1], pts[2], pts[3], shaded);
+            dl->AddQuad(pts[0], pts[1], pts[2], pts[3], IM_COL32(0, 0, 0, 0x80), 1.5f);
+            anyDrawn = true;
+        }
+        dl->PopClipRect();
+    }
+
+    // ---- Object axis gizmo (overlay in both modes; reads orientation) ----
+    if (st.showGizmo) {
+        dl->PushClipRect(origin, origin + size, true);
+        auto axis = [&](const glm::vec3& localEnd, ImU32 col, const char* label) {
+            ImVec2 a, b;
+            if (project(glm::vec3(0.f), a) && project(localEnd, b)) {
+                dl->AddLine(a, b, col, 2.f);
+                dl->AddText(b, col, label);
+            }
+        };
+        axis(glm::vec3(1.4f, 0.f, 0.f), IM_COL32(0xFF, 0x50, 0x50, 0xFF), "X");
+        axis(glm::vec3(0.f, 1.4f, 0.f), IM_COL32(0x50, 0xFF, 0x50, 0xFF), "Y");
+        axis(glm::vec3(0.f, 0.f, 1.4f), IM_COL32(0x60, 0x90, 0xFF, 0xFF), "Z");
+        dl->PopClipRect();
+    }
+
+    if (!anyDrawn) {
+        ImVec2 center(origin.x + size.x * 0.5f, origin.y + size.y * 0.5f);
+        const char* msg = scripts.empty() ? "No script loaded" : "Load a multi-axis script";
+        ImVec2 ts = ImGui::CalcTextSize(msg);
+        dl->AddText(ImVec2(center.x - ts.x * 0.5f, center.y - ts.y * 0.5f),
+                    IM_COL32(0xAA, 0xAA, 0xAA, 0xFF), msg);
+    }
+}

--- a/src/UI/OFS_Simulator3D.h
+++ b/src/UI/OFS_Simulator3D.h
@@ -13,6 +13,7 @@ struct Pose3D {
     float tx = 0.f, ty = 0.f, tz = 0.f;    // translation (sway, up, surge)
     float rx = 0.f, ry = 0.f, rz = 0.f;    // rotation radians (pitch X, twist Y, roll Z)
     float suck = 0.f, vib = 0.f, pump = 0.f; // 0..1 (pump centered at 0.5)
+    float stroke01 = 0.5f;                 // raw stroke axis value 0..1 (pre invert/range)
     bool hasStroke = false, hasSurge = false, hasSway = false;
     bool hasTwist = false, hasRoll = false, hasPitch = false;
     bool hasSuck = false, hasVib = false, hasPump = false;

--- a/src/UI/OFS_Simulator3D.h
+++ b/src/UI/OFS_Simulator3D.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+class Funscript;
+class LightingShader;
+struct Simulator3DState;
+
+// Rigid-body pose sampled from the loaded axes for one frame.
+struct Pose3D {
+    float tx = 0.f, ty = 0.f, tz = 0.f;    // translation (sway, up, surge)
+    float rx = 0.f, ry = 0.f, rz = 0.f;    // rotation radians (pitch X, twist Y, roll Z)
+    float suck = 0.f, vib = 0.f, pump = 0.f; // 0..1 (pump centered at 0.5)
+    bool hasStroke = false, hasSurge = false, hasSway = false;
+    bool hasTwist = false, hasRoll = false, hasPitch = false;
+    bool hasSuck = false, hasVib = false, hasPump = false;
+};
+
+// A 3D visualizer for multi-axis funscripts.
+// Samples the loaded axis scripts at the current playback time and drives a
+// rigid-body pose from up-down (main stroke) + surge/sway/twist/roll/pitch,
+// plus auxiliary suck/vib/pump deformation.
+//
+// Two render paths, selected by Simulator3DState::litMode:
+//   * fast   - flat box drawn through the ImGui draw list (grid + gizmo)
+//   * lit 3D - a procedural device mesh rendered to an FBO with the existing
+//              LightingShader (real depth testing + Phong lighting), shown via
+//              ImGui::Image. The mesh is generated in code; a future external
+//              model loader can replace buildMesh() without touching the rest.
+class Simulator3D {
+private:
+    uint32_t stateHandle = 0xFFFF'FFFFu;
+
+    // GL render-to-texture resources (created lazily on first lit-mode use).
+    std::unique_ptr<LightingShader> shader;
+    uint32_t fbo = 0, colorTex = 0, depthRbo = 0;
+    int fbWidth = 0, fbHeight = 0;
+    // Separate FBO for offscreen preview/export renders so they don't clash with
+    // the interactive window's fbo when both render in the same frame.
+    uint32_t exFbo = 0, exColorTex = 0, exDepthRbo = 0;
+    int exWidth = 0, exHeight = 0;
+    uint32_t vao = 0, vbo = 0;
+    int meshVertexCount = 0;
+    // Submesh vertex ranges for the colorable parts:
+    // 0=shaft, 1=twistL, 2=twistR, 3=tongue, 4=center.
+    static constexpr int PartCount = 5;
+    int partOffset[PartCount] = {0};
+    int partCount[PartCount] = {0};
+
+    void buildMesh() noexcept;
+    void ensureGL(int width, int height) noexcept;
+    void ensureExportGL(int width, int height) noexcept;
+    // Renders the mesh into targetFbo (sized w x h) with the given matrices.
+    void renderMeshToTexture(uint32_t targetFbo, int w, int h, const float* model, const float* view,
+                             const float* proj, const float* camPos, bool transparent) noexcept;
+    Pose3D samplePose(const std::vector<std::shared_ptr<Funscript>>& scripts, float time) noexcept;
+    // Renders the 3D scene into the current ImGui window. In overlay mode the
+    // camera is locked front-and-center, orbit is disabled, and the background
+    // is transparent so the video shows through.
+    void renderCanvas(Simulator3DState& st, const Pose3D& pose,
+                      const std::vector<std::shared_ptr<Funscript>>& scripts, bool overlay) noexcept;
+
+public:
+    static constexpr const char* WindowId = "###SIMULATOR_3D";
+
+    Simulator3D() noexcept;
+    ~Simulator3D() noexcept; // defined in .cpp (LightingShader is incomplete here)
+
+    void Init() noexcept;
+    void ShowWindow(bool* open, const std::vector<std::shared_ptr<class Funscript>>& scripts, float currentTime) noexcept;
+
+    // Offscreen render of the sim pose at `time` with a front-locked camera and
+    // transparent background, for the preview export. RenderPoseTexture returns a
+    // GL texture id; RenderPoseRGBA reads it back into a top-down RGBA buffer.
+    // Must be called on the main (GL) thread. Requires the lit render path.
+    uint32_t RenderPoseTexture(const std::vector<std::shared_ptr<Funscript>>& scripts, float time, int w, int h) noexcept;
+    bool RenderPoseRGBA(const std::vector<std::shared_ptr<Funscript>>& scripts, float time, int w, int h,
+                        std::vector<uint8_t>& outRGBA) noexcept;
+};

--- a/src/UI/OFS_Simulator3D.h
+++ b/src/UI/OFS_Simulator3D.h
@@ -10,7 +10,7 @@ struct Simulator3DState;
 
 // Rigid-body pose sampled from the loaded axes for one frame.
 struct Pose3D {
-    float tx = 0.f, ty = 0.f, tz = 0.f;    // translation (sway, up, surge)
+    float tx = 0.f, ty = 0.f, tz = 0.f;    // translation (surge, up, sway) - matches reference
     float rx = 0.f, ry = 0.f, rz = 0.f;    // rotation radians (pitch X, twist Y, roll Z)
     float suck = 0.f, vib = 0.f, pump = 0.f; // 0..1 (pump centered at 0.5)
     float stroke01 = 0.5f;                 // raw stroke axis value 0..1 (pre invert/range)

--- a/src/UI/OFS_Simulator3D.h
+++ b/src/UI/OFS_Simulator3D.h
@@ -41,8 +41,15 @@ private:
     // the interactive window's fbo when both render in the same frame.
     uint32_t exFbo = 0, exColorTex = 0, exDepthRbo = 0;
     int exWidth = 0, exHeight = 0;
+    // Supersampled FBO: the mesh is rendered here at 2x then downscaled into exFbo
+    // for antialiasing (smooth edges compress far better, esp. for lossless export).
+    uint32_t ssFbo = 0, ssColorTex = 0, ssDepthRbo = 0;
+    int ssWidth = 0, ssHeight = 0;
     uint32_t vao = 0, vbo = 0;
     int meshVertexCount = 0;
+    // Unit vertical box (y 0..1) drawn with a dynamic transform for the stroke-length line.
+    uint32_t lineVao = 0, lineVbo = 0;
+    int lineVertCount = 0;
     // Submesh vertex ranges for the colorable parts:
     // 0=shaft, 1=twistL, 2=twistR, 3=tongue, 4=center.
     static constexpr int PartCount = 5;

--- a/src/UI/OFS_Simulator3D.h
+++ b/src/UI/OFS_Simulator3D.h
@@ -10,7 +10,7 @@ struct Simulator3DState;
 
 // Rigid-body pose sampled from the loaded axes for one frame.
 struct Pose3D {
-    float tx = 0.f, ty = 0.f, tz = 0.f;    // translation (surge, up, sway) - matches reference
+    float tx = 0.f, ty = 0.f, tz = 0.f;    // translation (sway, up, surge)
     float rx = 0.f, ry = 0.f, rz = 0.f;    // rotation radians (pitch X, twist Y, roll Z)
     float suck = 0.f, vib = 0.f, pump = 0.f; // 0..1 (pump centered at 0.5)
     float stroke01 = 0.5f;                 // raw stroke axis value 0..1 (pre invert/range)

--- a/src/UI/OFS_TimelineRasterizer.cpp
+++ b/src/UI/OFS_TimelineRasterizer.cpp
@@ -17,7 +17,7 @@
 void OFS_TimelineRaster::DrawInto(ImDrawList* dl, const ImVec2& pos, const ImVec2& size,
                                   const std::vector<std::shared_ptr<Funscript>>& scripts,
                                   int activeIdx, float time, float visibleTime,
-                                  bool showHeightLines, bool allScripts) noexcept
+                                  bool showHeightLines, bool showLabels, bool allScripts) noexcept
 {
     if (size.x < 2.f || size.y < 2.f || visibleTime <= 0.f) return;
 
@@ -95,7 +95,7 @@ void OFS_TimelineRaster::DrawInto(ImDrawList* dl, const ImVec2& pos, const ImVec
         // Axis label (script title) so multi-axis strips are legible. Use an
         // explicit size (the offscreen font is loaded large) proportional to the lane.
         const auto& title = script->Title();
-        if (!title.empty()) {
+        if (showLabels && !title.empty()) {
             ImFont* lf = ImGui::GetFont();
             const float labelPx = Util::Clamp(laneH * 0.30f, 9.f, 20.f);
             const ImVec2 tp(laneMin.x + 4.f, laneMin.y + 2.f);
@@ -189,7 +189,7 @@ namespace
 
 bool OFS_TimelineRaster::Render(const std::vector<std::shared_ptr<Funscript>>& scripts,
                                 int activeIdx, float time, float visibleTime,
-                                int w, int h, bool showHeightLines, bool allScripts,
+                                int w, int h, bool showHeightLines, bool showLabels, bool allScripts,
                                 std::vector<uint8_t>& outRGBA) noexcept
 {
     if (w < 1 || h < 1 || visibleTime <= 0.f) return false;
@@ -214,7 +214,7 @@ bool OFS_TimelineRaster::Render(const std::vector<std::shared_ptr<Funscript>>& s
 
     ImDrawList* dl = ImGui::GetForegroundDrawList(ImGui::GetMainViewport());
     DrawInto(dl, ImVec2(0.f, 0.f), ImVec2((float)w, (float)h), scripts, activeIdx, time, visibleTime,
-             showHeightLines, allScripts);
+             showHeightLines, showLabels, allScripts);
 
     // Render the draw list into our offscreen framebuffer.
     glBindFramebuffer(GL_FRAMEBUFFER, g_fbo);

--- a/src/UI/OFS_TimelineRasterizer.cpp
+++ b/src/UI/OFS_TimelineRasterizer.cpp
@@ -1,0 +1,292 @@
+#include "OFS_TimelineRasterizer.h"
+
+#include "Funscript.h"
+#include "ScriptPositionsOverlayMode.h"
+
+#include "OFS_ImGui.h"
+#include "OFS_Shader.h"
+#include "OFS_GL.h"
+#include "OFS_Util.h"
+
+#include "imgui.h"
+#include "imgui_impl/imgui_impl_opengl3.h"
+
+#include <algorithm>
+#include <iterator>
+
+void OFS_TimelineRaster::DrawInto(ImDrawList* dl, const ImVec2& pos, const ImVec2& size,
+                                  const std::vector<std::shared_ptr<Funscript>>& scripts,
+                                  int activeIdx, float time, float visibleTime,
+                                  bool showHeightLines, bool allScripts) noexcept
+{
+    if (size.x < 2.f || size.y < 2.f || visibleTime <= 0.f) return;
+
+    // Which scripts to draw: all enabled, or just the active one.
+    std::vector<int> idxs;
+    if (allScripts) {
+        for (int i = 0; i < (int)scripts.size(); ++i)
+            if (scripts[i] && scripts[i]->Enabled) idxs.push_back(i);
+    }
+    if (idxs.empty()) {
+        if (activeIdx >= 0 && activeIdx < (int)scripts.size() && scripts[activeIdx]) idxs.push_back(activeIdx);
+    }
+    if (idxs.empty()) return;
+
+    const int n = (int)idxs.size();
+    constexpr float spacing = 2.f; // gap between lanes
+    const float laneH = (size.y - spacing * (n - 1)) / (float)n;
+    if (laneH < 2.f) return;
+
+    const float offsetTime = time - (visibleTime / 2.f);
+
+    // The strip always shows action lines + points; drive the editor's global
+    // flags on and restore them afterwards so the interactive timeline is unaffected.
+    const bool savedLines = BaseOverlay::ShowLines;
+    const bool savedPoints = BaseOverlay::ShowPoints;
+    const float savedPointSize = BaseOverlay::PointSize;
+    BaseOverlay::ShowLines = true;
+    BaseOverlay::ShowPoints = true;
+
+    for (int li = 0; li < n; ++li) {
+        const int si = idxs[li];
+        auto script = scripts[si].get();
+        if (!script) continue;
+
+        const float laneY = pos.y + (float)li * (laneH + spacing);
+        const ImVec2 laneMin(pos.x, laneY);
+        const ImVec2 laneMax(pos.x + size.x, laneY + laneH);
+
+        // Vertical inset so pos 0/100 point dots (and line ends) aren't clipped
+        // at the lane edges. MaxPointSize is 8.
+        const float margin = Util::Min(10.f, laneH * 0.25f);
+
+        // Lane background (matches the editor's inactive-script gradient).
+        dl->AddRectFilledMultiColor(laneMin, laneMax,
+            IM_COL32(0, 0, 50, 255), IM_COL32(0, 0, 50, 255),
+            IM_COL32(0, 0, 20, 255), IM_COL32(0, 0, 20, 255));
+        dl->PushClipRect(laneMin, laneMax, true);
+
+        OverlayDrawingCtx ctx = {};
+        ctx.scripts = &scripts;
+        ctx.drawingScriptIdx = si;
+        ctx.activeScriptIdx = activeIdx;
+        ctx.hoveredScriptIdx = -1;
+        ctx.drawnScriptCount = n;
+        ctx.drawList = dl;
+        ctx.canvasPos = ImVec2(laneMin.x, laneMin.y + margin);
+        ctx.canvasSize = ImVec2(size.x, laneH - 2.f * margin);
+        ctx.visibleTime = visibleTime;
+        ctx.offsetTime = offsetTime;
+        ctx.totalDuration = time + visibleTime; // unused by the calls below, just nonzero
+        ctx.selectionFromIdx = ctx.selectionToIdx = 0; // no selection highlight in export
+
+        auto& actions = script->Actions();
+        auto s = actions.lower_bound(FunscriptAction(offsetTime, 0));
+        if (s != actions.begin()) s -= 1;
+        auto e = actions.lower_bound(FunscriptAction(offsetTime + visibleTime, 0));
+        if (e != actions.end()) e += 1;
+        ctx.actionFromIdx = (int32_t)std::distance(actions.begin(), s);
+        ctx.actionToIdx = (int32_t)std::distance(actions.begin(), e);
+
+        if (showHeightLines) BaseOverlay::DrawHeightLines(ctx); // behind the actions
+        BaseOverlay::DrawActionLines(ctx);
+        BaseOverlay::DrawActionPoints(ctx);
+
+        // Axis label (script title) so multi-axis strips are legible. Use an
+        // explicit size (the offscreen font is loaded large) proportional to the lane.
+        const auto& title = script->Title();
+        if (!title.empty()) {
+            ImFont* lf = ImGui::GetFont();
+            const float labelPx = Util::Clamp(laneH * 0.30f, 9.f, 20.f);
+            const ImVec2 tp(laneMin.x + 4.f, laneMin.y + 2.f);
+            dl->AddText(lf, labelPx, ImVec2(tp.x + 1.f, tp.y + 1.f), IM_COL32(0, 0, 0, 220), title.c_str());
+            dl->AddText(lf, labelPx, tp, IM_COL32(255, 255, 255, 255), title.c_str());
+        }
+
+        // Lane border; highlight the active lane when several are stacked.
+        const uint32_t border = (si == activeIdx && n > 1) ? IM_COL32(0, 180, 0, 255)
+                                                           : IM_COL32(120, 120, 120, 255);
+        dl->AddRect(laneMin, laneMax, border);
+        dl->PopClipRect();
+    }
+
+    // Center playhead across the whole strip.
+    dl->AddLine(ImVec2(pos.x + size.x * 0.5f, pos.y), ImVec2(pos.x + size.x * 0.5f, pos.y + size.y),
+                IM_COL32(255, 255, 255, 255), 2.f);
+
+    BaseOverlay::ShowLines = savedLines;
+    BaseOverlay::ShowPoints = savedPoints;
+    BaseOverlay::PointSize = savedPointSize;
+}
+
+// A dedicated ImGui context + framebuffer kept alive across frames so a whole
+// export job doesn't pay the cost of rebuilding the font atlas each frame.
+// Created lazily on first use (main thread, GL current) and reused thereafter.
+namespace
+{
+    ImGuiContext* g_ctx = nullptr;
+    ImFont* g_font = nullptr;      // RobotoMono, for baked text labels
+    constexpr float kFontLoadPx = 64.f;
+    GLuint g_fbo = 0, g_colorTex = 0;
+    int g_w = 0, g_h = 0;
+    GLuint g_txFbo = 0, g_txTex = 0; // separate FBO for text overlays
+    int g_txW = 0, g_txH = 0;
+
+    void ensureContext() noexcept
+    {
+        if (g_ctx) return;
+        auto prev = ImGui::GetCurrentContext();
+        g_ctx = ImGui::CreateContext(); // own font atlas / draw-list shared data
+        ImGui::SetCurrentContext(g_ctx);
+        ImGui::GetIO().IniFilename = nullptr;
+        ImGui::GetIO().LogFilename = nullptr;
+        ImGui::StyleColorsDark();
+        // Load a real font for baked labels; falls back to the built-in font.
+        const auto fontPath = Util::Resource("fonts/RobotoMono-Regular.ttf");
+        g_font = ImGui::GetIO().Fonts->AddFontFromFileTTF(fontPath.c_str(), kFontLoadPx);
+        if (!g_font) g_font = ImGui::GetIO().Fonts->AddFontDefault();
+        ImGui_ImplOpenGL3_Init(OFS_SHADER_VERSION);
+        ImGui::SetCurrentContext(prev);
+    }
+
+    // Create/resize a framebuffer with an RGBA8 color texture. Returns success.
+    bool ensureFboImpl(GLuint& fbo, GLuint& tex, int& cw, int& ch, int w, int h) noexcept
+    {
+        if (fbo && w == cw && h == ch) return true;
+        if (!fbo) glGenFramebuffers(1, &fbo);
+        glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+        if (!tex) glGenTextures(1, &tex);
+        glBindTexture(GL_TEXTURE_2D, tex);
+        glTexImage2D(GL_TEXTURE_2D, 0, OFS_InternalTexFormat, w, h, 0, OFS_TexFormat, GL_UNSIGNED_BYTE, 0);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, tex, 0);
+        GLenum bufs[1] = { GL_COLOR_ATTACHMENT0 };
+        glDrawBuffers(1, bufs);
+        const bool ok = glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE;
+        glBindTexture(GL_TEXTURE_2D, 0);
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        if (ok) { cw = w; ch = h; }
+        return ok;
+    }
+
+    inline bool ensureFbo(int w, int h) noexcept { return ensureFboImpl(g_fbo, g_colorTex, g_w, g_h, w, h); }
+    inline bool ensureTextFbo(int w, int h) noexcept { return ensureFboImpl(g_txFbo, g_txTex, g_txW, g_txH, w, h); }
+
+    // Flip an RGBA buffer vertically in place (glReadPixels is bottom-up).
+    void flipY(std::vector<uint8_t>& buf, int w, int h) noexcept
+    {
+        const size_t stride = (size_t)w * 4u;
+        for (int y = 0; y < h / 2; ++y) {
+            uint8_t* a = buf.data() + (size_t)y * stride;
+            uint8_t* b = buf.data() + (size_t)(h - 1 - y) * stride;
+            std::swap_ranges(a, a + stride, b);
+        }
+    }
+}
+
+bool OFS_TimelineRaster::Render(const std::vector<std::shared_ptr<Funscript>>& scripts,
+                                int activeIdx, float time, float visibleTime,
+                                int w, int h, bool showHeightLines, bool allScripts,
+                                std::vector<uint8_t>& outRGBA) noexcept
+{
+    if (w < 1 || h < 1 || visibleTime <= 0.f) return false;
+
+    ensureContext();
+    if (!ensureFbo(w, h)) return false;
+
+    // Save caller GL/ImGui state we touch.
+    GLint prevFbo = 0, prevViewport[4] = {0, 0, 0, 0};
+    glGetIntegerv(GL_FRAMEBUFFER_BINDING, &prevFbo);
+    glGetIntegerv(GL_VIEWPORT, prevViewport);
+    auto prevCtx = ImGui::GetCurrentContext();
+
+    ImGui::SetCurrentContext(g_ctx);
+    auto& io = ImGui::GetIO();
+    io.DisplaySize = ImVec2((float)w, (float)h);
+    io.DisplayFramebufferScale = ImVec2(1.f, 1.f);
+    io.DeltaTime = 1.f / 60.f;
+
+    ImGui_ImplOpenGL3_NewFrame();
+    ImGui::NewFrame();
+
+    ImDrawList* dl = ImGui::GetForegroundDrawList(ImGui::GetMainViewport());
+    DrawInto(dl, ImVec2(0.f, 0.f), ImVec2((float)w, (float)h), scripts, activeIdx, time, visibleTime,
+             showHeightLines, allScripts);
+
+    // Render the draw list into our offscreen framebuffer.
+    glBindFramebuffer(GL_FRAMEBUFFER, g_fbo);
+    glViewport(0, 0, w, h);
+    glClearColor(0.f, 0.f, 0.f, 0.f);
+    glClear(GL_COLOR_BUFFER_BIT);
+
+    ImGui::Render();
+    OFS_ImGui::CurrentlyRenderedViewport = ImGui::GetMainViewport();
+    ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+    OFS_ImGui::CurrentlyRenderedViewport = nullptr;
+
+    outRGBA.resize((size_t)w * (size_t)h * 4u);
+    glReadPixels(0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, outRGBA.data());
+
+    // Restore caller state.
+    glBindFramebuffer(GL_FRAMEBUFFER, (GLuint)prevFbo);
+    glViewport(prevViewport[0], prevViewport[1], prevViewport[2], prevViewport[3]);
+    ImGui::SetCurrentContext(prevCtx);
+
+    flipY(outRGBA, w, h); // glReadPixels is bottom-up
+    return true;
+}
+
+bool OFS_TimelineRaster::RenderTextBottomCenter(const char* text, int w, int h,
+                                                std::vector<uint8_t>& outRGBA) noexcept
+{
+    if (w < 1 || h < 1 || !text || !*text) return false;
+
+    ensureContext();
+    if (!ensureTextFbo(w, h)) return false;
+
+    GLint prevFbo = 0, prevViewport[4] = {0, 0, 0, 0};
+    glGetIntegerv(GL_FRAMEBUFFER_BINDING, &prevFbo);
+    glGetIntegerv(GL_VIEWPORT, prevViewport);
+    auto prevCtx = ImGui::GetCurrentContext();
+
+    ImGui::SetCurrentContext(g_ctx);
+    auto& io = ImGui::GetIO();
+    io.DisplaySize = ImVec2((float)w, (float)h);
+    io.DisplayFramebufferScale = ImVec2(1.f, 1.f);
+    io.DeltaTime = 1.f / 60.f;
+
+    ImGui_ImplOpenGL3_NewFrame();
+    ImGui::NewFrame();
+
+    ImDrawList* dl = ImGui::GetForegroundDrawList(ImGui::GetMainViewport());
+    ImFont* font = g_font ? g_font : ImGui::GetFont();
+    // Size the text to the buffer height; scaling down from kFontLoadPx stays crisp.
+    const float fontPx = Util::Clamp((float)h * 0.14f, 12.f, kFontLoadPx);
+    const ImVec2 ts = font->CalcTextSizeA(fontPx, 1e9f, 0.f, text);
+    const ImVec2 tp((w - ts.x) * 0.5f, (float)h - ts.y - (float)h * 0.03f);
+    dl->AddText(font, fontPx, ImVec2(tp.x + 2.f, tp.y + 2.f), IM_COL32(0, 0, 0, 210), text); // shadow
+    dl->AddText(font, fontPx, tp, IM_COL32(255, 255, 255, 255), text);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, g_txFbo);
+    glViewport(0, 0, w, h);
+    glClearColor(0.f, 0.f, 0.f, 0.f);
+    glClear(GL_COLOR_BUFFER_BIT);
+
+    ImGui::Render();
+    OFS_ImGui::CurrentlyRenderedViewport = ImGui::GetMainViewport();
+    ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+    OFS_ImGui::CurrentlyRenderedViewport = nullptr;
+
+    outRGBA.resize((size_t)w * (size_t)h * 4u);
+    glReadPixels(0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, outRGBA.data());
+
+    glBindFramebuffer(GL_FRAMEBUFFER, (GLuint)prevFbo);
+    glViewport(prevViewport[0], prevViewport[1], prevViewport[2], prevViewport[3]);
+    ImGui::SetCurrentContext(prevCtx);
+
+    flipY(outRGBA, w, h);
+    return true;
+}

--- a/src/UI/OFS_TimelineRasterizer.h
+++ b/src/UI/OFS_TimelineRasterizer.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "imgui.h"
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+class Funscript;
+
+// Renders the scrolling script timeline (speed-gradient action lines, points and
+// a center playhead) using the editor's own BaseOverlay draw code, so the
+// exported strip matches what the user scripts against.
+namespace OFS_TimelineRaster
+{
+    // Draw the timeline strip into an existing draw list within [pos, pos+size].
+    // Used both for the live preview (app's ImGui frame) and the offscreen export.
+    //   activeIdx   : which script is "active" (lane highlighted when multi-axis).
+    //   time        : playhead time in seconds (centered horizontally).
+    //   visibleTime : seconds of script spanned across the width.
+    //   showHeightLines : draw the 10..90% reference grid behind the actions.
+    //   allScripts  : stack every enabled script in fixed-height lanes; otherwise
+    //                 draw only the active script.
+    void DrawInto(ImDrawList* dl, const ImVec2& pos, const ImVec2& size,
+                  const std::vector<std::shared_ptr<Funscript>>& scripts,
+                  int activeIdx, float time, float visibleTime,
+                  bool showHeightLines, bool allScripts) noexcept;
+
+    // Offscreen variant: renders DrawInto into a top-down, opaque RGBA buffer
+    // (w*h*4). Must run on the main thread with the app's GL context current.
+    // Returns false on invalid args.
+    bool Render(const std::vector<std::shared_ptr<Funscript>>& scripts,
+                int activeIdx, float time, float visibleTime,
+                int w, int h, bool showHeightLines, bool allScripts,
+                std::vector<uint8_t>& outRGBA) noexcept;
+
+    // Renders `text` centered along the bottom into a transparent, top-down RGBA
+    // buffer (w*h*4) using a real TrueType font. For baking readable labels onto
+    // exported frames. Main thread + GL context, same as Render.
+    bool RenderTextBottomCenter(const char* text, int w, int h,
+                                std::vector<uint8_t>& outRGBA) noexcept;
+}

--- a/src/UI/OFS_TimelineRasterizer.h
+++ b/src/UI/OFS_TimelineRasterizer.h
@@ -19,19 +19,20 @@ namespace OFS_TimelineRaster
     //   time        : playhead time in seconds (centered horizontally).
     //   visibleTime : seconds of script spanned across the width.
     //   showHeightLines : draw the 10..90% reference grid behind the actions.
+    //   showLabels  : draw each lane's axis name (script title).
     //   allScripts  : stack every enabled script in fixed-height lanes; otherwise
     //                 draw only the active script.
     void DrawInto(ImDrawList* dl, const ImVec2& pos, const ImVec2& size,
                   const std::vector<std::shared_ptr<Funscript>>& scripts,
                   int activeIdx, float time, float visibleTime,
-                  bool showHeightLines, bool allScripts) noexcept;
+                  bool showHeightLines, bool showLabels, bool allScripts) noexcept;
 
     // Offscreen variant: renders DrawInto into a top-down, opaque RGBA buffer
     // (w*h*4). Must run on the main thread with the app's GL context current.
     // Returns false on invalid args.
     bool Render(const std::vector<std::shared_ptr<Funscript>>& scripts,
                 int activeIdx, float time, float visibleTime,
-                int w, int h, bool showHeightLines, bool allScripts,
+                int w, int h, bool showHeightLines, bool showLabels, bool allScripts,
                 std::vector<uint8_t>& outRGBA) noexcept;
 
     // Renders `text` centered along the bottom into a transparent, top-down RGBA

--- a/src/lua/OFS_LuaCoreExtension.cpp
+++ b/src/lua/OFS_LuaCoreExtension.cpp
@@ -121,6 +121,7 @@ function binding.spline_smooth()
             time_ms = action2.at + (i*pointEverySecond)
             spline_pos = catmullRom(action1.pos, action2.pos, action3.pos, action4.pos, s)
             spline_pos = clamp(spline_pos, 0, 100)
+            spline_pos = math.floor(spline_pos + 0.5)
             table.insert( smoothedActions, {at=time_ms, pos=spline_pos} )
         end
         ::continue::

--- a/src/lua/api/OFS_LuaImGuiAPI.cpp
+++ b/src/lua/api/OFS_LuaImGuiAPI.cpp
@@ -2,6 +2,8 @@
 #include "imgui.h"
 #include "imgui_stdlib.h"
 
+#include <cmath>
+
 OFS_ImGuiAPI::OFS_ImGuiAPI(sol::usertype<class OFS_ExtensionAPI>& ofs) noexcept
 {
     ofs["Text"] = OFS_ImGuiAPI::Text;
@@ -101,10 +103,11 @@ std::tuple<lua_Number, bool> OFS_ImGuiAPI::DragNumber(const char* txt, lua_Numbe
     return std::make_tuple(current, valueChanged);
 }
 
-std::tuple<lua_Integer, bool> OFS_ImGuiAPI::DragInt(const char* txt, lua_Integer current, lua_Integer stepSize) noexcept
+std::tuple<lua_Integer, bool> OFS_ImGuiAPI::DragInt(const char* txt, lua_Number current, lua_Number stepSize) noexcept
 {
-    bool valueChanged = ImGui::DragScalar(txt, ImGuiDataType_S64, &current, stepSize);
-    return std::make_tuple(current, valueChanged);
+    lua_Integer value = (lua_Integer)std::llround(current);
+    bool valueChanged = ImGui::DragScalar(txt, ImGuiDataType_S64, &value, (float)stepSize);
+    return std::make_tuple(value, valueChanged);
 }
 
 std::tuple<std::string, bool> OFS_ImGuiAPI::InputText(const char* txt, std::string current) noexcept
@@ -113,10 +116,12 @@ std::tuple<std::string, bool> OFS_ImGuiAPI::InputText(const char* txt, std::stri
     return std::make_tuple(current, valueChanged);
 }
 
-std::tuple<lua_Integer, bool> OFS_ImGuiAPI::InputInt(const char* txt, lua_Integer current, lua_Integer stepSize) noexcept
+std::tuple<lua_Integer, bool> OFS_ImGuiAPI::InputInt(const char* txt, lua_Number current, lua_Number stepSize) noexcept
 {
-    bool valueChanged = ImGui::InputScalar(txt, ImGuiDataType_S64, &current, &stepSize);
-    return std::make_tuple(current, valueChanged);
+    lua_Integer value = (lua_Integer)std::llround(current);
+    lua_Integer step = (lua_Integer)std::llround(stepSize);
+    bool valueChanged = ImGui::InputScalar(txt, ImGuiDataType_S64, &value, &step);
+    return std::make_tuple(value, valueChanged);
 }
 
 std::tuple<lua_Number, bool> OFS_ImGuiAPI::InputNumber(const char* txt, lua_Number current, lua_Number stepSize) noexcept
@@ -131,16 +136,22 @@ std::tuple<lua_Number, bool> OFS_ImGuiAPI::SliderNumber(const char* txt, lua_Num
     return std::make_tuple(current, valueChanged);
 }
 
-std::tuple<lua_Integer, bool> OFS_ImGuiAPI::SliderInt(const char* txt, lua_Integer current, lua_Integer min, lua_Integer max) noexcept
+std::tuple<lua_Integer, bool> OFS_ImGuiAPI::SliderInt(const char* txt, lua_Number current, lua_Number min, lua_Number max) noexcept
 {
-    bool valueChanged = ImGui::SliderScalar(txt, ImGuiDataType_S64, &current, &min, &max);
-    return std::make_tuple(current, valueChanged);
+    lua_Integer value = (lua_Integer)std::llround(current);
+    lua_Integer mn = (lua_Integer)std::llround(min);
+    lua_Integer mx = (lua_Integer)std::llround(max);
+    bool valueChanged = ImGui::SliderScalar(txt, ImGuiDataType_S64, &value, &mn, &mx);
+    return std::make_tuple(value, valueChanged);
 }
 
-std::tuple<bool, bool> OFS_ImGuiAPI::Checkbox(const char* txt, bool current) noexcept
+std::tuple<bool, bool> OFS_ImGuiAPI::Checkbox(const char* txt, sol::optional<bool> current) noexcept
 {
-    bool valueChanged = ImGui::Checkbox(txt, &current);
-    return std::make_tuple(current, valueChanged);
+    // Tolerate a nil/absent second argument (treat as false) so plugins that
+    // pass an uninitialized state value don't error out.
+    bool value = current.value_or(false);
+    bool valueChanged = ImGui::Checkbox(txt, &value);
+    return std::make_tuple(value, valueChanged);
 }
 
 std::tuple<lua_Integer, bool> OFS_ImGuiAPI::Combo(const char* txt, lua_Integer currentSelection, sol::table items) noexcept

--- a/src/lua/api/OFS_LuaImGuiAPI.h
+++ b/src/lua/api/OFS_LuaImGuiAPI.h
@@ -23,24 +23,26 @@ class OFS_ImGuiAPI
     { return DragNumber(txt, current, 1.0); }
     static std::tuple<lua_Number, bool> DragNumber(const char* txt, lua_Number current, lua_Number stepSize) noexcept;
 
-    static std::tuple<lua_Integer, bool> DragIntWithoutStepSize(const char* txt, lua_Integer current) noexcept
+    // Integer widgets accept lua_Number and round internally so plugins passing
+    // a fractional Lua number (e.g. from arithmetic) don't error on marshalling.
+    static std::tuple<lua_Integer, bool> DragIntWithoutStepSize(const char* txt, lua_Number current) noexcept
     { return DragInt(txt, current, 1.0); }
-    static std::tuple<lua_Integer, bool> DragInt(const char* txt, lua_Integer current, lua_Integer stepSize) noexcept;
+    static std::tuple<lua_Integer, bool> DragInt(const char* txt, lua_Number current, lua_Number stepSize) noexcept;
 
     static std::tuple<std::string, bool> InputText(const char* txt, std::string current) noexcept;
 
-    static std::tuple<lua_Integer, bool> InputIntWithoutStepSize(const char* txt, lua_Integer current) noexcept
+    static std::tuple<lua_Integer, bool> InputIntWithoutStepSize(const char* txt, lua_Number current) noexcept
     { return InputInt(txt, current, 1); }
-    static std::tuple<lua_Integer, bool> InputInt(const char* txt, lua_Integer current, lua_Integer stepSize) noexcept;
+    static std::tuple<lua_Integer, bool> InputInt(const char* txt, lua_Number current, lua_Number stepSize) noexcept;
 
     static std::tuple<lua_Number, bool> InputNumberWithoutStepSize(const char* txt, lua_Number current) noexcept 
     { return InputNumber(txt, current, 0.0); }
     static std::tuple<lua_Number, bool> InputNumber(const char* txt, lua_Number current, lua_Number stepSize) noexcept;
 
     static std::tuple<lua_Number, bool> SliderNumber(const char* txt, lua_Number current, lua_Number min, lua_Number max) noexcept;
-    static std::tuple<lua_Integer, bool> SliderInt(const char* txt, lua_Integer current, lua_Integer min, lua_Integer max) noexcept;
+    static std::tuple<lua_Integer, bool> SliderInt(const char* txt, lua_Number current, lua_Number min, lua_Number max) noexcept;
 
-    static std::tuple<bool, bool> Checkbox(const char* txt, bool current) noexcept;
+    static std::tuple<bool, bool> Checkbox(const char* txt, sol::optional<bool> current) noexcept;
     static std::tuple<lua_Integer, bool> Combo(const char* txt, lua_Integer currentSelection, sol::table items) noexcept;
     static bool CollapsingHeader(const char* txt) noexcept;
 

--- a/src/lua/api/OFS_LuaScriptAPI.cpp
+++ b/src/lua/api/OFS_LuaScriptAPI.cpp
@@ -20,7 +20,7 @@ OFS_ScriptAPI::OFS_ScriptAPI(sol::usertype<class OFS_ExtensionAPI>& ofs) noexcep
     script["name"] = sol::readonly_property(&LuaFunscript::Name);
 
     auto action = L.new_usertype<LuaFunscriptAction>("Action",
-        sol::constructors<LuaFunscriptAction(lua_Number, lua_Integer), LuaFunscriptAction(lua_Number, lua_Integer, bool)>());
+        sol::constructors<LuaFunscriptAction(lua_Number, lua_Number), LuaFunscriptAction(lua_Number, lua_Number, bool)>());
     action["at"] = sol::property(&LuaFunscriptAction::at, &LuaFunscriptAction::set_at);
     action["pos"] = sol::property(&LuaFunscriptAction::pos, &LuaFunscriptAction::set_pos);
     action["selected"] = &LuaFunscriptAction::selected;

--- a/src/lua/api/OFS_LuaScriptAPI.h
+++ b/src/lua/api/OFS_LuaScriptAPI.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <tuple>
 #include <set>
+#include <cmath>
 
 struct LuaFunscriptAction
 {
@@ -16,12 +17,14 @@ struct LuaFunscriptAction
     LuaFunscriptAction(FunscriptAction action, bool selected) noexcept
         : o(action), selected(selected) 
     {}
-    LuaFunscriptAction(lua_Number at, lua_Integer pos) noexcept
+    // pos is taken as a lua_Number and rounded so plugins can pass computed
+    // (non-integral) positions; sol won't match a float against lua_Integer.
+    LuaFunscriptAction(lua_Number at, lua_Number pos) noexcept
     {
         o.atS = std::max(0.0, at);
-        o.pos = Util::Clamp<lua_Integer>(pos, 0, 100);
+        o.pos = (int16_t)Util::Clamp<lua_Integer>((lua_Integer)std::llround(pos), 0, 100);
     }
-    LuaFunscriptAction(lua_Number at, lua_Integer pos, bool selected) 
+    LuaFunscriptAction(lua_Number at, lua_Number pos, bool selected)
         : LuaFunscriptAction(at, pos)
     {
         this->selected = selected;
@@ -42,9 +45,9 @@ struct LuaFunscriptAction
         return o.pos;
     }
 
-    inline void set_pos(lua_Integer pos) noexcept
-    {            
-        o.pos = Util::Clamp<lua_Integer>(pos, 0, 100);
+    inline void set_pos(lua_Number pos) noexcept
+    {
+        o.pos = (int16_t)Util::Clamp<lua_Integer>((lua_Integer)std::llround(pos), 0, 100);
     }
 };
 

--- a/src/state/LineColorState.h
+++ b/src/state/LineColorState.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "OFS_StateHandle.h"
+
+#include <cstdint>
+#include <vector>
+
+// One stop of the action-line speed gradient. color is RGBA packed (ImU32).
+struct LineColorStop
+{
+    float pos = 0.f;           // 0..1 along the speed axis
+    uint32_t color = 0xFFFFFFFFu;
+};
+
+// Persisted choice of the timeline action-line color scheme.
+struct LineColorState
+{
+    static constexpr auto StateName = "LineColorState";
+
+    int32_t profile = 0; // 0 = Fork, 1 = Classic (OFS), 2 = Custom
+    std::vector<LineColorStop> customStops; // used when profile == Custom
+
+    inline static LineColorState& State(uint32_t stateHandle) noexcept
+    {
+        return OFS_AppState<LineColorState>(stateHandle).Get();
+    }
+};
+
+REFL_TYPE(LineColorStop)
+    REFL_FIELD(pos)
+    REFL_FIELD(color)
+REFL_END
+
+REFL_TYPE(LineColorState)
+    REFL_FIELD(profile)
+    REFL_FIELD(customStops)
+REFL_END

--- a/src/state/OpenFunscripterState.cpp
+++ b/src/state/OpenFunscripterState.cpp
@@ -6,6 +6,8 @@
 #include "ProjectState.h"
 #include "SpecialFunctionsState.h"
 #include "WebsocketApiState.h"
+#include "Simulator3DState.h"
+#include "PreviewExportState.h"
 
 void OpenFunscripterState::RegisterAll() noexcept
 {
@@ -17,6 +19,8 @@ void OpenFunscripterState::RegisterAll() noexcept
 	OFS_REGISTER_STATE(SimulatorDefaultConfigState);
 	OFS_REGISTER_STATE(SpecialFunctionState);
 	OFS_REGISTER_STATE(WebsocketApiState);
+	OFS_REGISTER_STATE(Simulator3DState);
+	OFS_REGISTER_STATE(PreviewExportState);
 
 	// Project state
 	OFS_REGISTER_STATE(TempoOverlayState);

--- a/src/state/OpenFunscripterState.cpp
+++ b/src/state/OpenFunscripterState.cpp
@@ -8,6 +8,7 @@
 #include "WebsocketApiState.h"
 #include "Simulator3DState.h"
 #include "PreviewExportState.h"
+#include "LineColorState.h"
 
 void OpenFunscripterState::RegisterAll() noexcept
 {
@@ -21,6 +22,7 @@ void OpenFunscripterState::RegisterAll() noexcept
 	OFS_REGISTER_STATE(WebsocketApiState);
 	OFS_REGISTER_STATE(Simulator3DState);
 	OFS_REGISTER_STATE(PreviewExportState);
+	OFS_REGISTER_STATE(LineColorState);
 
 	// Project state
 	OFS_REGISTER_STATE(TempoOverlayState);

--- a/src/state/OpenFunscripterState.h
+++ b/src/state/OpenFunscripterState.h
@@ -38,6 +38,7 @@ struct OpenFunscripterState
     bool alwaysShowBookmarkLabels = false;
     bool showHistory = true;
     bool showSimulator = true;
+    bool showSimulator3D = false;
     bool showSpecialFunctions = false;
     bool showWsApi = false;
     bool showChapterManager = false;
@@ -66,6 +67,7 @@ REFL_TYPE(OpenFunscripterState)
     REFL_FIELD(alwaysShowBookmarkLabels)
     REFL_FIELD(showHistory)
     REFL_FIELD(showSimulator)
+    REFL_FIELD(showSimulator3D)
     REFL_FIELD(showSpecialFunctions)
     REFL_FIELD(showWsApi)
     REFL_FIELD(showChapterManager)

--- a/src/state/PreviewExportState.h
+++ b/src/state/PreviewExportState.h
@@ -7,14 +7,15 @@ struct PreviewExportState
 {
     static constexpr auto StateName = "PreviewExportState";
 
-    int32_t format = 0;       // 0 = animated WebP, 1 = AV1 (webm)
-    int32_t resolution = 480; // output height in px (width keeps aspect)
+    int32_t format = 0;       // 0 = animated WebP (lossless), 1 = AV1 (mp4)
+    int32_t resolution = 480; // output height in px (width from video aspect)
     int32_t fps = 15;
-    int32_t quality = 75;     // 0..100 (higher = better)
+    int32_t av1Preset = 4;    // SVT-AV1 -preset, 0 (slow/best) .. 13 (fast)
     int32_t rangeMode = 0;    // 0 = chapter, 1 = timestamps
 
-    // Composite the 3D simulator onto the exported video.
+    // Composite the simulator onto the exported video.
     bool overlaySim = false;
+    bool sim2D = false; // use the flat 2D stroke bar instead of the 3D device
     // Normalized overlay rect on the video frame (0..1), top-left origin.
     float simX = 0.62f;
     float simY = 0.60f;
@@ -31,9 +32,10 @@ REFL_TYPE(PreviewExportState)
     REFL_FIELD(format)
     REFL_FIELD(resolution)
     REFL_FIELD(fps)
-    REFL_FIELD(quality)
+    REFL_FIELD(av1Preset)
     REFL_FIELD(rangeMode)
     REFL_FIELD(overlaySim)
+    REFL_FIELD(sim2D)
     REFL_FIELD(simX)
     REFL_FIELD(simY)
     REFL_FIELD(simW)

--- a/src/state/PreviewExportState.h
+++ b/src/state/PreviewExportState.h
@@ -28,6 +28,7 @@ struct PreviewExportState
     float timelineVisibleTime = 10.f;    // seconds of script shown across the strip
     float timelineHeightFrac = 0.22f;    // strip height as a fraction of video height
     bool timelineShowHeightLines = true; // draw the 10..90% reference grid
+    bool timelineShowLabels = true;      // draw the axis name (script title) on each lane
     bool timelineAllScripts = false;     // stack all enabled scripts (multi-axis)
 
     // Pillarbox/letterbox the video region to 16:9 with black bars.
@@ -56,6 +57,7 @@ REFL_TYPE(PreviewExportState)
     REFL_FIELD(timelineVisibleTime)
     REFL_FIELD(timelineHeightFrac)
     REFL_FIELD(timelineShowHeightLines)
+    REFL_FIELD(timelineShowLabels)
     REFL_FIELD(timelineAllScripts)
     REFL_FIELD(padTo169)
 REFL_END

--- a/src/state/PreviewExportState.h
+++ b/src/state/PreviewExportState.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "OFS_StateHandle.h"
+
+// Persisted settings for the animated preview (WebP/AV1) exporter.
+struct PreviewExportState
+{
+    static constexpr auto StateName = "PreviewExportState";
+
+    int32_t format = 0;       // 0 = animated WebP, 1 = AV1 (webm)
+    int32_t resolution = 480; // output height in px (width keeps aspect)
+    int32_t fps = 15;
+    int32_t quality = 75;     // 0..100 (higher = better)
+    int32_t rangeMode = 0;    // 0 = chapter, 1 = timestamps
+
+    // Composite the 3D simulator onto the exported video.
+    bool overlaySim = false;
+    // Normalized overlay rect on the video frame (0..1), top-left origin.
+    float simX = 0.62f;
+    float simY = 0.60f;
+    float simW = 0.34f;
+    float simH = 0.34f;
+
+    inline static PreviewExportState& State(uint32_t stateHandle) noexcept
+    {
+        return OFS_AppState<PreviewExportState>(stateHandle).Get();
+    }
+};
+
+REFL_TYPE(PreviewExportState)
+    REFL_FIELD(format)
+    REFL_FIELD(resolution)
+    REFL_FIELD(fps)
+    REFL_FIELD(quality)
+    REFL_FIELD(rangeMode)
+    REFL_FIELD(overlaySim)
+    REFL_FIELD(simX)
+    REFL_FIELD(simY)
+    REFL_FIELD(simW)
+    REFL_FIELD(simH)
+REFL_END

--- a/src/state/PreviewExportState.h
+++ b/src/state/PreviewExportState.h
@@ -34,6 +34,11 @@ struct PreviewExportState
     // Pillarbox/letterbox the video region to 16:9 with black bars.
     bool padTo169 = false;
 
+    // Compilation: sample several evenly-spread slices and concatenate them.
+    bool compilation = false;
+    int32_t compSlices = 6;      // number of slices
+    float compSliceDur = 2.f;    // duration of each slice in seconds
+
     inline static PreviewExportState& State(uint32_t stateHandle) noexcept
     {
         return OFS_AppState<PreviewExportState>(stateHandle).Get();
@@ -60,4 +65,7 @@ REFL_TYPE(PreviewExportState)
     REFL_FIELD(timelineShowLabels)
     REFL_FIELD(timelineAllScripts)
     REFL_FIELD(padTo169)
+    REFL_FIELD(compilation)
+    REFL_FIELD(compSlices)
+    REFL_FIELD(compSliceDur)
 REFL_END

--- a/src/state/PreviewExportState.h
+++ b/src/state/PreviewExportState.h
@@ -21,6 +21,17 @@ struct PreviewExportState
     float simY = 0.60f;
     float simW = 0.34f;
     float simH = 0.34f;
+    bool simShowHeightText = false; // draw the current position (0..100) on the sim
+
+    // Append the scrolling script timeline as a band beneath the video.
+    bool overlayTimeline = false;
+    float timelineVisibleTime = 10.f;    // seconds of script shown across the strip
+    float timelineHeightFrac = 0.22f;    // strip height as a fraction of video height
+    bool timelineShowHeightLines = true; // draw the 10..90% reference grid
+    bool timelineAllScripts = false;     // stack all enabled scripts (multi-axis)
+
+    // Pillarbox/letterbox the video region to 16:9 with black bars.
+    bool padTo169 = false;
 
     inline static PreviewExportState& State(uint32_t stateHandle) noexcept
     {
@@ -40,4 +51,11 @@ REFL_TYPE(PreviewExportState)
     REFL_FIELD(simY)
     REFL_FIELD(simW)
     REFL_FIELD(simH)
+    REFL_FIELD(simShowHeightText)
+    REFL_FIELD(overlayTimeline)
+    REFL_FIELD(timelineVisibleTime)
+    REFL_FIELD(timelineHeightFrac)
+    REFL_FIELD(timelineShowHeightLines)
+    REFL_FIELD(timelineAllScripts)
+    REFL_FIELD(padTo169)
 REFL_END

--- a/src/state/Simulator3DState.h
+++ b/src/state/Simulator3DState.h
@@ -38,6 +38,8 @@ struct Simulator3DState
     bool showGrid = true;
     bool showGizmo = true;
     bool showStrokeLine = false; // vertical line from the cylinder bottom to the ground (stroke length)
+    bool showHeightText = false;   // draw the stroke position (0..100) under the model
+    float heightTextScale = 1.f;   // readout size as a multiple of the UI font size
     bool litMode = false; // false = fast draw-list box; true = GPU lit mesh (render-to-texture)
     bool overlayMode = false; // render in a floating window over the video (front-locked, no orbit)
 
@@ -77,6 +79,8 @@ REFL_TYPE(Simulator3DState)
     REFL_FIELD(showGrid)
     REFL_FIELD(showGizmo)
     REFL_FIELD(showStrokeLine)
+    REFL_FIELD(showHeightText)
+    REFL_FIELD(heightTextScale)
     REFL_FIELD(litMode)
     REFL_FIELD(overlayMode)
     REFL_FIELD(shaftColor)

--- a/src/state/Simulator3DState.h
+++ b/src/state/Simulator3DState.h
@@ -21,10 +21,12 @@ struct Simulator3DState
     float camDist = 4.5f;
 
     // Axis -> motion mapping ranges
+    // Ranges match the reference OFS_Simulator3D (OpenFunscripter/OFS_Simulator3D):
+    // stroke Lerp(-1,1), surge/sway Lerp(-0.5,0.5), twist +/-120, roll & pitch +/-45.
     float translateRange = 1.0f; // world units (stroke; surge/sway are half this)
-    float twistRange = 135.f;    // degrees (matches original simulator)
-    float rollRange = 30.f;      // degrees (matches original simulator)
-    float pitchRange = 30.f;     // degrees (matches original simulator)
+    float twistRange = 120.f;    // degrees
+    float rollRange = 45.f;      // degrees
+    float pitchRange = 45.f;     // degrees
 
     // Per-axis direction inversion (for matching hardware / convention)
     bool invertStroke = false;

--- a/src/state/Simulator3DState.h
+++ b/src/state/Simulator3DState.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include "imgui.h"
+#include "OFS_StateHandle.h"
+
+// Persisted configuration for the 3D multi-axis simulator.
+// App-global (not per-project): camera framing and axis mapping are treated as
+// a user preference. Registered in OpenFunscripterState::RegisterAll().
+struct Simulator3DState
+{
+    static constexpr auto StateName = "Simulator3DState";
+
+    // Device preset: 0 = All axes, 1 = SR6 (6-axis), 2 = OSR2+ (stroke+twist+roll+pitch).
+    // Controls which axes are driven so the preview matches real hardware.
+    int32_t device = 0;
+
+    // Orbit camera. Default is a straight-on front view (yaw/pitch 0), which
+    // faces the +Z orientation marker toward the viewer. "Recenter" resets here.
+    float camYaw = 0.0f;    // radians
+    float camPitch = 0.0f;  // radians
+    float camDist = 4.5f;
+
+    // Axis -> motion mapping ranges
+    float translateRange = 1.0f; // world units (stroke; surge/sway are half this)
+    float twistRange = 135.f;    // degrees (matches original simulator)
+    float rollRange = 30.f;      // degrees (matches original simulator)
+    float pitchRange = 30.f;     // degrees (matches original simulator)
+
+    // Per-axis direction inversion (for matching hardware / convention)
+    bool invertStroke = false;
+    bool invertSurge = false;
+    bool invertSway = false;
+    bool invertTwist = false;
+    bool invertRoll = false;
+    bool invertPitch = false;
+
+    // Display aids
+    bool showGrid = true;
+    bool showGizmo = true;
+    bool litMode = false; // false = fast draw-list box; true = GPU lit mesh (render-to-texture)
+    bool overlayMode = false; // render in a floating window over the video (front-locked, no orbit)
+
+    // Per-part colors. Roles map to the standard's parts:
+    //   shaftColor = stroker, markerColor = twist marker L (red), baseColor = twist marker R (purple)
+    ImColor shaftColor = ImColor(0.10f, 0.62f, 0.86f, 1.f);
+    ImColor markerColor = ImColor(0.90f, 0.15f, 0.15f, 1.f); // twist L (red)
+    ImColor baseColor = ImColor(0.51f, 0.12f, 0.85f, 1.f);   // twist R (purple)
+
+    // Optional extras (like the standard's hidden-by-default tongue).
+    bool showTongue = false;
+    bool showCenter = false; // optional 3rd (center) orientation indicator
+    ImColor tongueColor = ImColor(1.f, 0.38f, 0.38f, 1.f);   // matches standard tongue pink
+    ImColor centerColor = ImColor(0.20f, 0.85f, 0.35f, 1.f); // center indicator (green)
+
+    inline static Simulator3DState& State(uint32_t stateHandle) noexcept
+    {
+        return OFS_AppState<Simulator3DState>(stateHandle).Get();
+    }
+};
+
+REFL_TYPE(Simulator3DState)
+    REFL_FIELD(device)
+    REFL_FIELD(camYaw)
+    REFL_FIELD(camPitch)
+    REFL_FIELD(camDist)
+    REFL_FIELD(translateRange)
+    REFL_FIELD(twistRange)
+    REFL_FIELD(rollRange)
+    REFL_FIELD(pitchRange)
+    REFL_FIELD(invertStroke)
+    REFL_FIELD(invertSurge)
+    REFL_FIELD(invertSway)
+    REFL_FIELD(invertTwist)
+    REFL_FIELD(invertRoll)
+    REFL_FIELD(invertPitch)
+    REFL_FIELD(showGrid)
+    REFL_FIELD(showGizmo)
+    REFL_FIELD(litMode)
+    REFL_FIELD(overlayMode)
+    REFL_FIELD(shaftColor)
+    REFL_FIELD(baseColor)
+    REFL_FIELD(markerColor)
+    REFL_FIELD(showTongue)
+    REFL_FIELD(showCenter)
+    REFL_FIELD(tongueColor)
+    REFL_FIELD(centerColor)
+REFL_END

--- a/src/state/Simulator3DState.h
+++ b/src/state/Simulator3DState.h
@@ -37,6 +37,7 @@ struct Simulator3DState
     // Display aids
     bool showGrid = true;
     bool showGizmo = true;
+    bool showStrokeLine = false; // vertical line from the cylinder bottom to the ground (stroke length)
     bool litMode = false; // false = fast draw-list box; true = GPU lit mesh (render-to-texture)
     bool overlayMode = false; // render in a floating window over the video (front-locked, no orbit)
 
@@ -75,6 +76,7 @@ REFL_TYPE(Simulator3DState)
     REFL_FIELD(invertPitch)
     REFL_FIELD(showGrid)
     REFL_FIELD(showGizmo)
+    REFL_FIELD(showStrokeLine)
     REFL_FIELD(litMode)
     REFL_FIELD(overlayMode)
     REFL_FIELD(shaftColor)


### PR DESCRIPTION
Two larger features from my fork ([SaekoM/OFS](https://github.com/SaekoM/OFS)), plus a few smaller additions that grew out of them. Everything is opt-in: no window opens, no shortcut fires and no color changes unless the user turns it on, so existing behaviour and existing configs are untouched.

### 3D multi-axis simulator
`View > 3D Simulator`. Renders the loaded scripts on a 3D device instead of the flat bar, so multi-axis work can be checked without loading the project into a separate simulator.

- Drives stroke + surge / sway / twist / roll / pitch from the axis scripts, using the TCode channel-suffix convention already used for multi-axis loading.
- Mesh and default motion ranges match the widely used reference simulator (OpenFunscripter/OFS_Simulator3D): stroker cylinder with opposing twist markers, optional tongue and center indicator, twist ±120°, roll/pitch ±45°. Rotation order is Rz(roll) · Rx(pitch) · Ry(twist) with twist applied locally, so the model spins about its own shaft rather than precessing once roll/pitch are engaged.
- Device presets — All axes / SR6 / OSR2+ — restrict the driven axes to what the hardware actually has, plus per-axis invert and range sliders.
- Orbit camera with recenter / reset-ranges, ground grid, axis gizmo, per-part colors, and an optional stroke-position readout (0–100) drawn under the model.
- Two draw paths: a fast ImGui draw-list path (default) and a GPU-lit render-to-texture path.
- Overlay mode puts the simulator in a borderless, movable/resizable window over the video.

### Animated preview export
`View > Preview Exporter`, or right-click a chapter → Export preview. Produces a short shareable clip of a script instead of a still heatmap.

- Output: animated WebP (lossless) or AV1 in mp4 (libsvtav1, selectable preset), at a chosen height and fps, from a chapter or a typed HH:MM:SS.mmm range.
- Optionally composites the simulator onto the video — the 3D device or a flat 2D stroke bar that reuses the user's existing 2D-simulator colors, height lines and indicators — placed with a draggable live-preview box.
- Optionally appends a scrolling timeline strip beneath the video, drawn with the editor's own BaseOverlay code (OFS_TimelineRasterizer) so the exported strip matches what you script against; supports stacked lanes with axis labels for multi-axis projects.
- Compilation mode samples N evenly spread slices of a chosen length across the whole video and concatenates them into one preview. AV1 compilations concatenate audio too, falling back to video-only when the source has no audio track (via a new OFS_Videoplayer::HasAudio(), backed by an mpv aid property observation).
- Overlay frames render incrementally on the main thread (a few per app frame) so the UI never blocks; ffmpeg then runs once on a background thread with stderr captured and logged.

### Selectable action-line color profiles
`Preferences > Scripting` gets an action-line color picker: the current Fork palette (the detailed 41-stop speed gradient, unchanged default), the original OFS Classic palette (white → green → yellow → red), or a Custom gradient edited stop by stop with a live preview. FunscriptHeatmap gains LinePreset() / SetLineColors() so the gradient can be rebuilt at runtime.

The Classic preset compresses its stops into the first 400/2000 of the speed axis, because the original normalized speed to 400 where this normalizes to 2000 — without that the stops land on the pale low end and look washed out. The compressed mapping is numerically identical to the original (fully red at ≥ 400/s). Only the timeline action lines are affected; the exported heatmap image keeps the existing shader palette.

### Smaller changes
- Shift + 1…0 keybinds for the intermediate positions 5, 15, … 95 (with localization rows).
- `Project > Add > Shortcuts > All` (surge, sway, twist, roll, pitch) creates the five positional axes in one click, skipping any already loaded.
- Fixes an ImGui "empty ID at the root of a window" assert when opening File > Recent files: an entry with an empty name produced an empty MenuItem ID. Each entry now seeds its ID from its index and falls back to (unnamed).
- Lua API tolerance — Checkbox accepts a missing/nil value, and SliderInt / InputInt / DragInt take lua_Number and round, so existing community extensions stop erroring on int/float marshalling.
- OFS_DynFontAtlas::NumberFont: a digits-only 96px RobotoMono face, rebuilt with the other fonts. The simulator readout scales down from it instead of upscaling the UI font, which stayed soft. Limited to 0-9 so the atlas cost stays negligible.
- Build: set(CMAKE_POLICY_VERSION_MINIMUM 3.5) at the top of the root CMakeLists.txt so the bundled submodules (glm, SDL2, json, bitsery, civetweb, eventpp), which still declare cmake_minimum_required() below 3.5, configure under CMake 4.x without patching each one.
- The bundled ffmpeg download switches from the gyan essentials build to full, which is the only one carrying libsvtav1 (needed for AV1 export). Users with a cached ffmpeg.exe / ffmpeg.zip in the OFS pref dir need to delete them to re-pull.